### PR TITLE
flatmap-filter optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rayon = "1.9.0"
 test-case = "3.3.1"
 
 [[bench]]
-name = "map_filter_collect_large"
+name = "flatmap_insignificant_work"
 harness = false
 
 [features]

--- a/benches/flatmap_insignificant_work.rs
+++ b/benches/flatmap_insignificant_work.rs
@@ -1,5 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use orx_parallel::*;
+use orx_split_vec::SplitVec;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use rayon::iter::IntoParallelIterator;
@@ -27,7 +28,11 @@ fn rayon(inputs: &[u32]) -> Vec<usize> {
     inputs.into_par_iter().flat_map(map).collect()
 }
 
-fn orx_parallel_default(inputs: &[u32]) -> Vec<usize> {
+fn orx_parallel_split_vec(inputs: &[u32]) -> SplitVec<usize> {
+    inputs.into_par().flat_map(map).collect()
+}
+
+fn orx_parallel_vec(inputs: &[u32]) -> Vec<usize> {
     inputs.into_par().flat_map(map).collect_vec()
 }
 
@@ -42,7 +47,8 @@ fn orx_parallel(inputs: &[u32], num_threads: usize, chunk_size: usize) -> Vec<us
 
 fn flat_map_insignificant_work(c: &mut Criterion) {
     let treatments = vec![65_536, 262_144 * 4];
-    let params = [(1, 1), (4, 256), (8, 1024), (32, 1024)];
+    let _params = [(1, 1), (4, 256), (8, 1024), (32, 1024)];
+    let params = [];
 
     let mut group = c.benchmark_group("flat_map_insignificant_work");
 
@@ -55,17 +61,18 @@ fn flat_map_insignificant_work(c: &mut Criterion) {
         });
 
         group.bench_with_input(BenchmarkId::new("rayon", n), n, |b, _| {
-            b.iter(|| {
-                let result = rayon(black_box(&input));
-                assert_eq!(result, expected);
-            })
+            assert_eq!(rayon(&input), expected);
+            b.iter(|| rayon(black_box(&input)))
         });
 
-        group.bench_with_input(BenchmarkId::new("orx-parallel-default", n), n, |b, _| {
-            b.iter(|| {
-                let result = orx_parallel_default(black_box(&input));
-                assert_eq!(result, expected);
-            })
+        group.bench_with_input(BenchmarkId::new("orx-parallel-split-vec", n), n, |b, _| {
+            assert_eq!(orx_parallel_split_vec(&input), expected);
+            b.iter(|| orx_parallel_split_vec(black_box(&input)))
+        });
+
+        group.bench_with_input(BenchmarkId::new("orx-parallel-vec", n), n, |b, _| {
+            assert_eq!(orx_parallel_vec(&input), expected);
+            b.iter(|| orx_parallel_vec(black_box(&input)))
         });
 
         for (t, c) in params {

--- a/src/core/flatmap_fil_col.rs
+++ b/src/core/flatmap_fil_col.rs
@@ -1,139 +1,123 @@
-use super::diagnostics::ParThreadLogger;
+use super::map_fil_col::{heap_sort_into_pinned_vec, heap_sort_into_vec};
 use super::runner::{ParTask, Runner};
 use crate::Params;
-use orx_concurrent_bag::ConcurrentBag;
 use orx_concurrent_iter::ConcurrentIter;
-use orx_concurrent_ordered_bag::ConcurrentOrderedBag;
 use orx_fixed_vec::PinnedVec;
-use std::cmp::Ordering;
 
-pub fn par_fmap_fil_col<I, OutIter, Out, Map, Fil, P, Q>(
-    params: Params,
-    iter: I,
-    map: Map,
-    filter: Fil,
-    collected: ConcurrentBag<Out, P>,
-    pos_len: ConcurrentOrderedBag<(usize, usize), Q>,
-) -> (P, Q)
-where
-    I: ConcurrentIter,
-    OutIter: IntoIterator<Item = Out>,
-    Out: Send + Sync,
-    Map: Fn(I::Item) -> OutIter + Send + Sync,
-    Fil: Fn(&Out) -> bool + Send + Sync,
-    P: PinnedVec<Out>,
-    Q: PinnedVec<(usize, usize)>,
-{
-    #[cfg(feature = "with_diagnostics")]
-    return par_fmap_fil_col_core::<_, _, _, _, _, _, _, super::diagnostics::ParLogger>(
-        params, iter, map, filter, collected, pos_len,
-    );
-
-    #[cfg(not(feature = "with_diagnostics"))]
-    par_fmap_fil_col_core::<_, _, _, _, _, _, _, super::diagnostics::NoLogger>(
-        params, iter, map, filter, collected, pos_len,
-    )
-}
-
-fn par_fmap_fil_col_core<I, OutIter, Out, Map, Fil, P, Q, L>(
-    params: Params,
-    iter: I,
-    map: Map,
-    filter: Fil,
-    collected: ConcurrentBag<Out, P>,
-    pos_len: ConcurrentOrderedBag<(usize, usize), Q>,
-) -> (P, Q)
-where
-    I: ConcurrentIter,
-    OutIter: IntoIterator<Item = Out>,
-    Out: Send + Sync,
-    Map: Fn(I::Item) -> OutIter + Send + Sync,
-    Fil: Fn(&Out) -> bool + Send + Sync,
-    P: PinnedVec<Out>,
-    Q: PinnedVec<(usize, usize)>,
-    L: ParThreadLogger,
-{
-    let offset = collected.len();
-    let task =
-        |c| task::<_, _, _, _, _, _, _, L>(&iter, &map, &filter, &collected, &pos_len, offset, c);
-    let num_spawned = Runner::run(params, ParTask::Collect, &iter, &task);
-
-    L::log_num_spawned(num_spawned);
-    (collected.into_inner(), unsafe {
-        pos_len.into_inner().unwrap_only_if_counts_match()
-    })
-}
-
-fn task<I, OutIter, Out, Map, Fil, P, Q, L>(
+fn task<I, OutIter, Out, FlatMap, Fil>(
     iter: &I,
-    map: &Map,
+    flat_map: &FlatMap,
     filter: &Fil,
-    collected: &ConcurrentBag<Out, P>,
-    pos_len: &ConcurrentOrderedBag<(usize, usize), Q>,
-    offset: usize,
     chunk_size: usize,
-) where
+) -> Vec<((usize, usize), Out)>
+where
     I: ConcurrentIter,
     OutIter: IntoIterator<Item = Out>,
     Out: Send + Sync,
-    Map: Fn(I::Item) -> OutIter + Send + Sync,
+    FlatMap: Fn(I::Item) -> OutIter + Send + Sync,
     Fil: Fn(&Out) -> bool + Send + Sync,
-    P: PinnedVec<Out>,
-    Q: PinnedVec<(usize, usize)>,
-    L: ParThreadLogger,
 {
-    let logger = L::new(chunk_size);
+    let mut collected = vec![];
     match chunk_size {
         1 => {
             while let Some(x) = iter.next_id_and_value() {
-                let idx = offset + x.idx;
-                let buffer: Vec<_> = map(x.value).into_iter().filter(filter).collect();
-                let len = buffer.len();
-                let begin_position = collected.extend(buffer);
-                unsafe { pos_len.set_value(idx, (begin_position, len)) };
+                collected.extend(
+                    flat_map(x.value)
+                        .into_iter()
+                        .filter(filter)
+                        .enumerate()
+                        .map(|(i, value)| ((x.idx, i), value)),
+                );
             }
         }
         c => {
             let mut buffered = iter.buffered_iter(c);
-            let mut local = vec![(usize::MAX, 0); c];
             while let Some(chunk) = buffered.next() {
-                logger.next_chunk(chunk.values.len());
-
-                let count = chunk.values.len();
-                let begin_idx = offset + chunk.begin_idx;
-                let buffer: Vec<Out> = chunk.values.flat_map(map).filter(filter).collect();
-                let buffer_len = buffer.len();
-                let begin_position = collected.extend(buffer);
-                local[0] = (begin_position, buffer_len);
-                unsafe {
-                    match count.cmp(&c) {
-                        Ordering::Less => {
-                            pos_len.set_values(begin_idx, local.iter().take(count).cloned())
-                        }
-                        _ => pos_len.set_values(begin_idx, local.iter().cloned()),
-                    }
-                };
+                for (c, value) in chunk.values.enumerate() {
+                    collected.extend(
+                        flat_map(value)
+                            .into_iter()
+                            .filter(filter)
+                            .enumerate()
+                            .map(|(i, value)| ((chunk.begin_idx + c, i), value)),
+                    );
+                }
             }
         }
     }
+    collected
 }
 
-pub fn seq_fmap_fil_col<I, OutIter, Out, Map, Fil, Output, Push>(
+pub fn par_flatmap_fil_col_vec<I, OutIter, Out, FlatMap, Fil>(
+    params: Params,
     iter: I,
-    map: Map,
+    flat_map: FlatMap,
     filter: Fil,
-    output: &mut Output,
-    mut push: Push,
+    output: &mut Vec<Out>,
 ) where
     I: ConcurrentIter,
     OutIter: IntoIterator<Item = Out>,
     Out: Send + Sync,
-    Map: Fn(I::Item) -> OutIter + Send + Sync,
+    FlatMap: Fn(I::Item) -> OutIter + Send + Sync,
     Fil: Fn(&Out) -> bool + Send + Sync,
-    Push: FnMut(&mut Output, Out),
+{
+    let task = |c| task(&iter, &flat_map, &filter, c);
+    let vectors = Runner::run_map(params, ParTask::Collect, &iter, &task);
+    heap_sort_into_vec(vectors, output);
+}
+
+pub fn par_flatmap_fil_col_pinned_vec<I, OutIter, Out, FlatMap, Fil, P>(
+    params: Params,
+    iter: I,
+    flat_map: FlatMap,
+    filter: Fil,
+    output: &mut P,
+) where
+    I: ConcurrentIter,
+    OutIter: IntoIterator<Item = Out>,
+    Out: Send + Sync,
+    FlatMap: Fn(I::Item) -> OutIter + Send + Sync,
+    Fil: Fn(&Out) -> bool + Send + Sync,
+    P: PinnedVec<Out>,
+{
+    let task = |c| task(&iter, &flat_map, &filter, c);
+    let vectors = Runner::run_map(params, ParTask::Collect, &iter, &task);
+    heap_sort_into_pinned_vec(vectors, output);
+}
+
+pub fn seq_flatmap_fil_col_vec<I, OutIter, Out, FlatMap, Fil>(
+    iter: I,
+    flat_map: FlatMap,
+    filter: Fil,
+    output: &mut Vec<Out>,
+) where
+    I: ConcurrentIter,
+    OutIter: IntoIterator<Item = Out>,
+    Out: Send + Sync,
+    FlatMap: Fn(I::Item) -> OutIter + Send + Sync,
+    Fil: Fn(&Out) -> bool + Send + Sync,
 {
     let iter = iter.into_seq_iter();
-    for x in iter.flat_map(map).filter(filter) {
-        push(output, x);
+    for x in iter.flat_map(flat_map).filter(filter) {
+        output.push(x);
+    }
+}
+
+pub fn seq_flatmap_fil_col_pinned_vec<I, OutIter, Out, FlatMap, Fil, P>(
+    iter: I,
+    flat_map: FlatMap,
+    filter: Fil,
+    output: &mut P,
+) where
+    I: ConcurrentIter,
+    OutIter: IntoIterator<Item = Out>,
+    Out: Send + Sync,
+    FlatMap: Fn(I::Item) -> OutIter + Send + Sync,
+    Fil: Fn(&Out) -> bool + Send + Sync,
+    P: PinnedVec<Out>,
+{
+    let iter = iter.into_seq_iter();
+    for x in iter.flat_map(flat_map).filter(filter) {
+        output.push(x);
     }
 }

--- a/src/core/flatmap_fil_col_deprecated.rs
+++ b/src/core/flatmap_fil_col_deprecated.rs
@@ -1,0 +1,139 @@
+use super::diagnostics::ParThreadLogger;
+use super::runner::{ParTask, Runner};
+use crate::Params;
+use orx_concurrent_bag::ConcurrentBag;
+use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_ordered_bag::ConcurrentOrderedBag;
+use orx_fixed_vec::PinnedVec;
+use std::cmp::Ordering;
+
+pub fn par_fmap_fil_col<I, OutIter, Out, Map, Fil, P, Q>(
+    params: Params,
+    iter: I,
+    map: Map,
+    filter: Fil,
+    collected: ConcurrentBag<Out, P>,
+    pos_len: ConcurrentOrderedBag<(usize, usize), Q>,
+) -> (P, Q)
+where
+    I: ConcurrentIter,
+    OutIter: IntoIterator<Item = Out>,
+    Out: Send + Sync,
+    Map: Fn(I::Item) -> OutIter + Send + Sync,
+    Fil: Fn(&Out) -> bool + Send + Sync,
+    P: PinnedVec<Out>,
+    Q: PinnedVec<(usize, usize)>,
+{
+    #[cfg(feature = "with_diagnostics")]
+    return par_fmap_fil_col_core::<_, _, _, _, _, _, _, super::diagnostics::ParLogger>(
+        params, iter, map, filter, collected, pos_len,
+    );
+
+    #[cfg(not(feature = "with_diagnostics"))]
+    par_fmap_fil_col_core::<_, _, _, _, _, _, _, super::diagnostics::NoLogger>(
+        params, iter, map, filter, collected, pos_len,
+    )
+}
+
+fn par_fmap_fil_col_core<I, OutIter, Out, Map, Fil, P, Q, L>(
+    params: Params,
+    iter: I,
+    map: Map,
+    filter: Fil,
+    collected: ConcurrentBag<Out, P>,
+    pos_len: ConcurrentOrderedBag<(usize, usize), Q>,
+) -> (P, Q)
+where
+    I: ConcurrentIter,
+    OutIter: IntoIterator<Item = Out>,
+    Out: Send + Sync,
+    Map: Fn(I::Item) -> OutIter + Send + Sync,
+    Fil: Fn(&Out) -> bool + Send + Sync,
+    P: PinnedVec<Out>,
+    Q: PinnedVec<(usize, usize)>,
+    L: ParThreadLogger,
+{
+    let offset = collected.len();
+    let task =
+        |c| task::<_, _, _, _, _, _, _, L>(&iter, &map, &filter, &collected, &pos_len, offset, c);
+    let num_spawned = Runner::run(params, ParTask::Collect, &iter, &task);
+
+    L::log_num_spawned(num_spawned);
+    (collected.into_inner(), unsafe {
+        pos_len.into_inner().unwrap_only_if_counts_match()
+    })
+}
+
+fn task<I, OutIter, Out, Map, Fil, P, Q, L>(
+    iter: &I,
+    map: &Map,
+    filter: &Fil,
+    collected: &ConcurrentBag<Out, P>,
+    pos_len: &ConcurrentOrderedBag<(usize, usize), Q>,
+    offset: usize,
+    chunk_size: usize,
+) where
+    I: ConcurrentIter,
+    OutIter: IntoIterator<Item = Out>,
+    Out: Send + Sync,
+    Map: Fn(I::Item) -> OutIter + Send + Sync,
+    Fil: Fn(&Out) -> bool + Send + Sync,
+    P: PinnedVec<Out>,
+    Q: PinnedVec<(usize, usize)>,
+    L: ParThreadLogger,
+{
+    let logger = L::new(chunk_size);
+    match chunk_size {
+        1 => {
+            while let Some(x) = iter.next_id_and_value() {
+                let idx = offset + x.idx;
+                let buffer: Vec<_> = map(x.value).into_iter().filter(filter).collect();
+                let len = buffer.len();
+                let begin_position = collected.extend(buffer);
+                unsafe { pos_len.set_value(idx, (begin_position, len)) };
+            }
+        }
+        c => {
+            let mut buffered = iter.buffered_iter(c);
+            let mut local = vec![(usize::MAX, 0); c];
+            while let Some(chunk) = buffered.next() {
+                logger.next_chunk(chunk.values.len());
+
+                let count = chunk.values.len();
+                let begin_idx = offset + chunk.begin_idx;
+                let buffer: Vec<Out> = chunk.values.flat_map(map).filter(filter).collect();
+                let buffer_len = buffer.len();
+                let begin_position = collected.extend(buffer);
+                local[0] = (begin_position, buffer_len);
+                unsafe {
+                    match count.cmp(&c) {
+                        Ordering::Less => {
+                            pos_len.set_values(begin_idx, local.iter().take(count).cloned())
+                        }
+                        _ => pos_len.set_values(begin_idx, local.iter().cloned()),
+                    }
+                };
+            }
+        }
+    }
+}
+
+pub fn seq_fmap_fil_col<I, OutIter, Out, Map, Fil, Output, Push>(
+    iter: I,
+    map: Map,
+    filter: Fil,
+    output: &mut Output,
+    mut push: Push,
+) where
+    I: ConcurrentIter,
+    OutIter: IntoIterator<Item = Out>,
+    Out: Send + Sync,
+    Map: Fn(I::Item) -> OutIter + Send + Sync,
+    Fil: Fn(&Out) -> bool + Send + Sync,
+    Push: FnMut(&mut Output, Out),
+{
+    let iter = iter.into_seq_iter();
+    for x in iter.flat_map(map).filter(filter) {
+        push(output, x);
+    }
+}

--- a/src/core/map_fil_col.rs
+++ b/src/core/map_fil_col.rs
@@ -34,7 +34,10 @@ where
     collected
 }
 
-fn join_vec<Out>(mut vectors: Vec<Vec<(usize, Out)>>, output: &mut Vec<Out>) {
+pub(crate) fn heap_sort_into_vec<Out, Key>(mut vectors: Vec<Vec<(Key, Out)>>, output: &mut Vec<Out>)
+where
+    Key: Copy + PartialOrd,
+{
     let mut queue = BinaryHeap::with_capacity(vectors.len());
     let mut indices = vec![0; vectors.len()];
 
@@ -63,8 +66,11 @@ fn join_vec<Out>(mut vectors: Vec<Vec<(usize, Out)>>, output: &mut Vec<Out>) {
     }
 }
 
-fn join_pinned_vec<Out, P>(mut vectors: Vec<Vec<(usize, Out)>>, output: &mut P)
-where
+pub(crate) fn heap_sort_into_pinned_vec<Out, Key, P>(
+    mut vectors: Vec<Vec<(Key, Out)>>,
+    output: &mut P,
+) where
+    Key: PartialOrd + Copy,
     P: PinnedVec<Out>,
 {
     let mut queue = BinaryHeap::with_capacity(vectors.len());
@@ -109,7 +115,7 @@ pub fn par_map_fil_col_vec<I, Out, Map, Fil>(
 {
     let task = |c| task(&iter, &map, &filter, c);
     let vectors = Runner::run_map(params, ParTask::Collect, &iter, &task);
-    join_vec(vectors, output);
+    heap_sort_into_vec(vectors, output);
 }
 
 pub fn par_map_fil_col_pinned_vec<I, Out, Map, Fil, P>(
@@ -127,7 +133,7 @@ pub fn par_map_fil_col_pinned_vec<I, Out, Map, Fil, P>(
 {
     let task = |c| task(&iter, &map, &filter, c);
     let vectors = Runner::run_map(params, ParTask::Collect, &iter, &task);
-    join_pinned_vec(vectors, output);
+    heap_sort_into_pinned_vec(vectors, output);
 }
 
 pub fn seq_map_fil_col_vec<I, Out, Map, Fil>(iter: I, map: Map, filter: Fil, output: &mut Vec<Out>)

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -6,6 +6,7 @@ pub mod filtermap_fil_find;
 pub mod filtermap_fil_red;
 pub mod flatmap_fil_cnt;
 pub mod flatmap_fil_col;
+// pub mod flatmap_fil_col_deprecated;
 pub mod flatmap_fil_colx;
 pub mod flatmap_fil_find;
 pub mod flatmap_fil_red;

--- a/src/par/collect_into/collect_into_core.rs
+++ b/src/par/collect_into/collect_into_core.rs
@@ -52,41 +52,6 @@ pub trait ParCollectIntoCore<O: Send + Sync + Debug> {
 const ERR_SRC: &str = "is in bounds";
 const ERR_DST: &str = "output has enough capacity";
 
-pub fn merge_bag_and_pos_len<T, P, Q, O>(mut bag: P, pos_len: &Q, output: &mut O)
-where
-    T: Debug,
-    P: PinnedVec<T> + Debug,
-    O: PinnedVec<T> + Debug,
-    Q: PinnedVec<(usize, usize)> + Debug,
-{
-    match bag.is_empty() {
-        true => {}
-        false => {
-            assert!(output.capacity() >= bag.len());
-
-            let mut des_idx = output.len();
-
-            for &x in pos_len.iter().filter(|x| x.0 < usize::MAX && x.1 > 0) {
-                let (begin_idx, len) = (x.0, x.1);
-
-                for i in 0..len {
-                    let src_idx = begin_idx + i;
-
-                    let source_ptr = unsafe { bag.get_ptr_mut(src_idx) }.expect(ERR_SRC);
-                    let destination_ptr = unsafe { output.get_ptr_mut(des_idx) }.expect(ERR_DST);
-
-                    unsafe { destination_ptr.write(source_ptr.read()) };
-
-                    des_idx += 1;
-                }
-            }
-
-            unsafe { output.set_len(des_idx) };
-            let _ = ManuallyDrop::new(bag);
-        }
-    }
-}
-
 pub fn merge_bag_and_positions<T, P, Q, O>(mut bag: P, positions: &Q, output: &mut O)
 where
     T: Debug,

--- a/src/par/fallible.rs
+++ b/src/par/fallible.rs
@@ -91,7 +91,7 @@ pub trait Fallible<T> {
 impl<T> Fallible<T> for Option<T> {
     #[inline(always)]
     fn value(self) -> T {
-        self.unwrap()
+        self.expect("`value` called on failure (None).")
     }
 
     #[inline(always)]
@@ -103,7 +103,7 @@ impl<T> Fallible<T> for Option<T> {
 impl<T, E: Debug> Fallible<T> for Result<T, E> {
     #[inline(always)]
     fn value(self) -> T {
-        self.unwrap()
+        self.expect("`value` called on failure (Err).")
     }
 
     #[inline(always)]

--- a/src/par/par_flatmap_fil.rs
+++ b/src/par/par_flatmap_fil.rs
@@ -1,22 +1,19 @@
 use super::{
-    par_filtermap::ParFilterMap, par_flatmap::ParFlatMap, par_map::ParMap, reduce::Reduce,
+    collect_into::collect_into_core::ParCollectIntoCore, par_filtermap::ParFilterMap,
+    par_flatmap::ParFlatMap, par_map::ParMap, reduce::Reduce,
 };
 use crate::{
     core::{
         flatmap_fil_cnt::fmap_fil_cnt,
-        flatmap_fil_col::{par_fmap_fil_col, seq_fmap_fil_col},
         flatmap_fil_colx::{par_fmap_fil_colx, seq_fmap_fil_colx},
         flatmap_fil_find::fmap_fil_find,
         flatmap_fil_red::fmap_fil_red,
     },
     fn_sync::FnSync,
-    par::collect_into::collect_into_core::merge_bag_and_pos_len,
     ParCollectInto, ParIter, Params,
 };
 use orx_concurrent_bag::ConcurrentBag;
 use orx_concurrent_iter::{ConIterOfVec, ConcurrentIter, IntoConcurrentIter};
-use orx_concurrent_ordered_bag::ConcurrentOrderedBag;
-use orx_fixed_vec::FixedVec;
 use orx_pinned_vec::PinnedVec;
 use orx_split_vec::{Recursive, SplitVec};
 use std::fmt::Debug;
@@ -55,41 +52,11 @@ where
         }
     }
 
-    fn destruct(self) -> (Params, I, M, F) {
+    pub(crate) fn destruct(self) -> (Params, I, M, F) {
         (self.params, self.iter, self.flat_map, self.filter)
     }
 
     // collect
-
-    pub(crate) fn collect_bag_par<Output, NewOutput>(self, new_output: NewOutput) -> Output
-    where
-        Output: PinnedVec<O> + Debug,
-        NewOutput: FnOnce(usize) -> Output,
-    {
-        debug_assert!(!self.params.is_sequential());
-
-        let (params, iter, flat_map, filter) = self.destruct();
-
-        let bag = ConcurrentBag::new();
-        let positions = ConcurrentOrderedBag::new();
-        let (bag, pos_len) = par_fmap_fil_col(params, iter, flat_map, filter, bag, positions);
-        let mut output = new_output(bag.len());
-        merge_bag_and_pos_len(bag, &pos_len, &mut output);
-        output
-    }
-
-    pub(crate) fn collect_bag_seq<Output, Push>(self, mut output: Output, push: Push) -> Output
-    where
-        Push: FnMut(&mut Output, O),
-    {
-        debug_assert!(self.params.is_sequential());
-
-        let (_, iter, flat_map, filter) = self.destruct();
-
-        seq_fmap_fil_col(iter, flat_map, filter, &mut output, push);
-        output
-    }
-
     pub(crate) fn collect_bag_x<P>(self, collected: ConcurrentBag<O, P>) -> ConcurrentBag<O, P>
     where
         P: PinnedVec<O>,
@@ -201,24 +168,11 @@ where
     // collect
 
     fn collect_vec(self) -> Vec<Self::Item> {
-        match self.params.is_sequential() {
-            true => self.collect_bag_seq(Vec::new(), |v, x| v.push(x)),
-            false => self.collect_bag_par(|len| FixedVec::new(len)).into(),
-        }
+        Vec::new().flatmap_filter_into(self)
     }
 
     fn collect(self) -> SplitVec<Self::Item> {
-        match self.params.is_sequential() {
-            true => self.collect_bag_seq(SplitVec::new(), |v, x| v.push(x)),
-            false => {
-                let new_output = |len| {
-                    let mut vec = SplitVec::new();
-                    unsafe { _ = vec.grow_to(len, false) };
-                    vec
-                };
-                self.collect_bag_par(new_output)
-            }
-        }
+        SplitVec::new().flatmap_filter_into(self)
     }
 
     fn collect_into<C: ParCollectInto<Self::Item>>(self, output: C) -> C {


### PR DESCRIPTION
`collect` methods on flat-map with or without filter are optimized. In a 32 logical thread cpu, benchmarks are very promising: ~20 times faster than rayon. rayon seems to underperform sequential execution for some reason. orx-parallel, on the other hand, provides 8-10 times improvement over sequential. See "benches/flatmap.rs" or other variants.

Applied optimization is through using a binary heap to sort a sorted list of vectors. Further, we take advantage of composed push-and-pop operation to further improve the speed.

Even in the large-output benchmarks, where writing the output overweighs the computation, orx-parallel still outperforms.

In the special case where the work to be done as well as the size of the output are both insignificant, sequential is 70 times faster than rayon. While orx-parallel is only 30% slower when there are too few elements and 3 times faster when the input is longer. All together, new implementation seems to be very robust in different use cases.