### PR TITLE
Unordered iteration is redefined

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-parallel"
-version = "1.9.0"
+version = "1.10.0"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "A performant and configurable parallel computing library for computations defined as compositions of iterator methods."
@@ -18,14 +18,14 @@ orx-pinned-concurrent-col = "2.6"
 orx-concurrent-bag = "2.6"
 orx-concurrent-ordered-bag = "2.6"
 orx-priority-queue = "1.3"
-orx-concurrent-iter = "1.26"
+orx-concurrent-iter = "1.27"
 
 [dev-dependencies]
 chrono = "0.4.38"
 criterion = "0.5.1"
 rand = "0.8"
 rand_chacha = "0.3"
-rayon = "1.9.0"
+rayon = "1.10.0"
 test-case = "3.3.1"
 
 [[bench]]

--- a/benches/all_pairs_dijkstra.rs
+++ b/benches/all_pairs_dijkstra.rs
@@ -1,7 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use orx_parallel::*;
+use orx_parallel::prelude::*;
 use orx_priority_queue::{BinaryHeap, PriorityQueue};
-use orx_split_vec::{Recursive, SplitVec};
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};

--- a/benches/filter_map_reduce_sum.rs
+++ b/benches/filter_map_reduce_sum.rs
@@ -1,5 +1,4 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use orx_concurrent_iter::*;
 use orx_parallel::*;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
@@ -59,9 +58,9 @@ fn rayon_reduce_with(inputs: &[String]) -> Option<usize> {
 
 fn orx_parallel_default(inputs: &[String]) -> Option<usize> {
     inputs
-        .into_con_iter()
+        .iter()
         .cloned()
-        .into_par()
+        .par()
         .map(map)
         .filter(fil)
         .reduce(red)
@@ -69,9 +68,9 @@ fn orx_parallel_default(inputs: &[String]) -> Option<usize> {
 
 fn orx_parallel(inputs: &[String], num_threads: usize, chunk_size: usize) -> Option<usize> {
     inputs
-        .into_con_iter()
+        .iter()
         .cloned()
-        .into_par()
+        .par()
         .num_threads(num_threads)
         .chunk_size(chunk_size)
         .map(map)

--- a/benches/filter_reduce_sum.rs
+++ b/benches/filter_reduce_sum.rs
@@ -1,5 +1,4 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use orx_concurrent_iter::*;
 use orx_parallel::*;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
@@ -42,19 +41,14 @@ fn rayon_reduce_with(inputs: &[usize]) -> Option<usize> {
 }
 
 fn orx_parallel_default(inputs: &[usize]) -> Option<usize> {
-    inputs
-        .into_con_iter()
-        .cloned()
-        .into_par()
-        .filter(fil)
-        .reduce(red)
+    inputs.iter().cloned().par().filter(fil).reduce(red)
 }
 
 fn orx_parallel(inputs: &[usize], num_threads: usize, chunk_size: usize) -> Option<usize> {
     inputs
-        .into_con_iter()
+        .iter()
         .cloned()
-        .into_par()
+        .par()
         .num_threads(num_threads)
         .chunk_size(chunk_size)
         .filter(fil)

--- a/benches/filtermap_collect.rs
+++ b/benches/filtermap_collect.rs
@@ -1,6 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use orx_parallel::*;
-use orx_split_vec::{Recursive, SplitVec};
+use orx_parallel::prelude::*;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use rayon::iter::IntoParallelIterator;
@@ -66,7 +65,7 @@ fn orx_parallel_split_vec(inputs: &[u32]) -> SplitVec<u32> {
     inputs.into_par().filter_map(filter_map).collect()
 }
 
-fn orx_parallel_split_rec(inputs: &[u32]) -> SplitVec<u32, Recursive> {
+fn orx_parallel_split_rec(inputs: &[u32]) -> SplitVec<u32, impl Growth + '_> {
     inputs.into_par().filter_map(filter_map).collect_x()
 }
 

--- a/benches/flatmap.rs
+++ b/benches/flatmap.rs
@@ -1,6 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use orx_parallel::*;
-use orx_split_vec::{Recursive, SplitVec};
+use orx_parallel::prelude::*;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use rayon::iter::IntoParallelIterator;

--- a/benches/flatmap_heterogeneous.rs
+++ b/benches/flatmap_heterogeneous.rs
@@ -1,6 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use orx_parallel::*;
-use orx_split_vec::{Recursive, SplitVec};
+use orx_parallel::prelude::*;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use rayon::iter::IntoParallelIterator;

--- a/benches/flatmap_insignificant_work.rs
+++ b/benches/flatmap_insignificant_work.rs
@@ -1,6 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use orx_parallel::*;
-use orx_split_vec::{Recursive, SplitVec};
+use orx_parallel::prelude::*;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use rayon::iter::IntoParallelIterator;

--- a/benches/flatmap_large_output.rs
+++ b/benches/flatmap_large_output.rs
@@ -1,6 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use orx_parallel::*;
-use orx_split_vec::{Recursive, SplitVec};
+use orx_parallel::prelude::*;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use rayon::iter::IntoParallelIterator;

--- a/benches/iter_reduce_concat.rs
+++ b/benches/iter_reduce_concat.rs
@@ -1,0 +1,164 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use orx_parallel::*;
+use rand::prelude::*;
+use rand_chacha::ChaCha8Rng;
+use rayon::iter::{IntoParallelIterator, ParallelBridge};
+
+const SEED: u64 = 54487;
+
+fn inputs(len: usize) -> Vec<String> {
+    let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+    (0..len)
+        .map(|_| rng.gen_range(0..1000))
+        .map(|x| x.to_string())
+        .collect()
+}
+
+fn red(a: String, b: String) -> String {
+    format!("{}{}", a, b)
+}
+
+fn seq(inputs: &[String]) -> Option<String> {
+    inputs.iter().cloned().filter(|x| x.len() > 1).reduce(red)
+}
+
+fn rayon_reduce(inputs: &[String]) -> Option<String> {
+    use rayon::iter::ParallelIterator;
+    Some(
+        inputs
+            .iter()
+            .cloned()
+            .filter(|x| x.len() > 1)
+            .par_bridge()
+            .into_par_iter()
+            .reduce(|| String::new(), red),
+    )
+}
+
+fn rayon_reduce_with(inputs: &[String]) -> Option<String> {
+    use rayon::iter::ParallelIterator;
+    inputs
+        .iter()
+        .cloned()
+        .filter(|x| x.len() > 1)
+        .par_bridge()
+        .into_par_iter()
+        .reduce_with(red)
+}
+
+fn orx_parallel_reduce(inputs: &[String], num_threads: usize, chunk_size: usize) -> Option<String> {
+    inputs
+        .iter()
+        .cloned()
+        .filter(|x| x.len() > 1)
+        .par()
+        .num_threads(num_threads)
+        .chunk_size(chunk_size)
+        .reduce(red)
+}
+
+fn orx_parallel_fold(inputs: &[String], num_threads: usize, chunk_size: usize) -> Option<String> {
+    Some(
+        inputs
+            .iter()
+            .cloned()
+            .filter(|x| x.len() > 1)
+            .par()
+            .num_threads(num_threads)
+            .chunk_size(chunk_size)
+            .fold(|| String::new(), red),
+    )
+}
+
+fn orx_parallel_default(inputs: &[String]) -> Option<String> {
+    inputs
+        .iter()
+        .cloned()
+        .filter(|x| x.len() > 1)
+        .par()
+        .reduce(red)
+}
+
+fn into_sorted_chars(result: Option<String>) -> Vec<char> {
+    let mut vec: Vec<_> = result.unwrap().chars().collect();
+    vec.sort();
+    vec
+}
+
+fn iter_reduce_concat(c: &mut Criterion) {
+    let lengths = [1024, 1024 * 4];
+
+    let mut group = c.benchmark_group("iter_reduce_concat");
+
+    for len in lengths {
+        let input = inputs(len);
+        let name = format!("n{}", len);
+        let expected = into_sorted_chars(seq(&input));
+
+        group.bench_with_input(BenchmarkId::new("seq", name.clone()), &name, |b, _| {
+            assert_eq!(expected, into_sorted_chars(seq(&input)));
+            b.iter(|| {
+                let _ = seq(&input);
+            })
+        });
+
+        group.bench_with_input(
+            BenchmarkId::new("rayon_reduce", name.clone()),
+            &name,
+            |b, _| {
+                assert_eq!(expected, into_sorted_chars(rayon_reduce(&input)));
+                b.iter(|| {
+                    let _ = rayon_reduce(&input);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("rayon_reduce_with", name.clone()),
+            &name,
+            |b, _| {
+                assert_eq!(expected, into_sorted_chars(rayon_reduce_with(&input)));
+                b.iter(|| {
+                    let _ = rayon_reduce_with(&input);
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("orx-parallel-default", name.clone()),
+            &name,
+            |b, _| {
+                assert_eq!(expected, into_sorted_chars(orx_parallel_default(&input)));
+                b.iter(|| {
+                    let _ = orx_parallel_default(&input);
+                })
+            },
+        );
+
+        let t = 8;
+        let c = 1024;
+        let par_str = format!("orx-parallel-reduce-t{}-c{}", t, c);
+        group.bench_with_input(BenchmarkId::new(par_str, name.clone()), &name, |b, _| {
+            assert_eq!(
+                expected,
+                into_sorted_chars(orx_parallel_reduce(&input, t, c))
+            );
+            b.iter(|| {
+                let _ = orx_parallel_reduce(black_box(&input), t, c);
+            })
+        });
+
+        let par_str = format!("orx-parallel-fold-t{}-c{}", t, c);
+        group.bench_with_input(BenchmarkId::new(par_str, name.clone()), &name, |b, _| {
+            assert_eq!(expected, into_sorted_chars(orx_parallel_fold(&input, t, c)));
+            b.iter(|| {
+                let _ = orx_parallel_fold(black_box(&input), t, c);
+            })
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, iter_reduce_concat);
+criterion_main!(benches);

--- a/benches/map_collect.rs
+++ b/benches/map_collect.rs
@@ -1,6 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use orx_parallel::*;
-use orx_split_vec::SplitVec;
+use orx_parallel::prelude::*;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use rayon::iter::IntoParallelIterator;

--- a/benches/map_filter_collect.rs
+++ b/benches/map_filter_collect.rs
@@ -1,6 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use orx_parallel::*;
-use orx_split_vec::{Recursive, SplitVec};
+use orx_parallel::prelude::*;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use rayon::iter::IntoParallelIterator;

--- a/benches/map_filter_collect_large.rs
+++ b/benches/map_filter_collect_large.rs
@@ -1,6 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use orx_parallel::*;
-use orx_split_vec::{Recursive, SplitVec};
+use orx_parallel::prelude::*;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use rayon::iter::IntoParallelIterator;

--- a/benches/map_filter_reduce.rs
+++ b/benches/map_filter_reduce.rs
@@ -1,5 +1,4 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use orx_concurrent_iter::*;
 use orx_parallel::*;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
@@ -64,9 +63,9 @@ fn orx_parallel_custom_reduce(
     chunk_size: usize,
 ) -> Option<usize> {
     inputs
-        .into_con_iter()
+        .iter()
         .cloned()
-        .into_par()
+        .par()
         .num_threads(num_threads)
         .chunk_size(chunk_size)
         .reduce(reduce)

--- a/benches/map_find_expensive.rs
+++ b/benches/map_find_expensive.rs
@@ -1,10 +1,8 @@
-use std::num::NonZeroUsize;
-
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use orx_parallel::*;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use rayon::iter::IntoParallelIterator;
+use std::num::NonZeroUsize;
 
 const SEED: u64 = 745;
 const FIB_UPPER_BOUND: u32 = 9999;

--- a/benches/map_reduce_avg.rs
+++ b/benches/map_reduce_avg.rs
@@ -1,5 +1,4 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use orx_concurrent_iter::*;
 use orx_parallel::*;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
@@ -53,9 +52,9 @@ fn rayon_reduce_with(inputs: &[usize]) -> Option<usize> {
 
 fn orx_parallel_reduce(inputs: &[usize], num_threads: usize, chunk_size: usize) -> Option<usize> {
     inputs
-        .into_con_iter()
+        .iter()
         .cloned()
-        .into_par()
+        .par()
         .num_threads(num_threads)
         .chunk_size(chunk_size)
         .map(map)
@@ -66,9 +65,9 @@ fn orx_parallel_reduce(inputs: &[usize], num_threads: usize, chunk_size: usize) 
 fn orx_parallel_sum(inputs: &[usize], num_threads: usize, chunk_size: usize) -> Option<usize> {
     Some(
         inputs
-            .into_con_iter()
+            .iter()
             .cloned()
-            .into_par()
+            .par()
             .num_threads(num_threads)
             .chunk_size(chunk_size)
             .sum()
@@ -77,7 +76,7 @@ fn orx_parallel_sum(inputs: &[usize], num_threads: usize, chunk_size: usize) -> 
 }
 
 fn orx_parallel_default(inputs: &[usize]) -> Option<usize> {
-    Some(inputs.into_con_iter().cloned().into_par().sum() / inputs.len())
+    Some(inputs.iter().cloned().par().sum() / inputs.len())
 }
 
 fn map_reduce_avg(c: &mut Criterion) {

--- a/benches/reduce_black_box_sum.rs
+++ b/benches/reduce_black_box_sum.rs
@@ -1,5 +1,4 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use orx_concurrent_iter::*;
 use orx_parallel::*;
 use rand::prelude::*;
 use rand_chacha::ChaCha8Rng;
@@ -32,16 +31,16 @@ fn rayon_reduce_with(inputs: &[usize]) -> Option<usize> {
 
 fn orx_parallel(inputs: &[usize], num_threads: usize, chunk_size: usize) -> Option<usize> {
     inputs
-        .into_con_iter()
+        .iter()
         .cloned()
-        .into_par()
+        .par()
         .num_threads(num_threads)
         .chunk_size(chunk_size)
         .reduce(red)
 }
 
 fn orx_parallel_default(inputs: &[usize]) -> Option<usize> {
-    inputs.into_con_iter().cloned().into_par().reduce(red)
+    inputs.iter().cloned().par().reduce(red)
 }
 
 fn reduce_black_box_sum(c: &mut Criterion) {

--- a/src/core/filtermap_fil_cnt.rs
+++ b/src/core/filtermap_fil_cnt.rs
@@ -1,6 +1,6 @@
 use super::runner::{ParTask, Runner};
 use crate::{Fallible, Params};
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::ConcurrentIterX;
 
 pub fn filtermap_fil_cnt<I, FO, Out, FilterMap, Fil>(
     params: Params,
@@ -9,7 +9,7 @@ pub fn filtermap_fil_cnt<I, FO, Out, FilterMap, Fil>(
     filter: Fil,
 ) -> usize
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     FO: Fallible<Out> + Send + Sync,
     Out: Send + Sync,
     FilterMap: Fn(I::Item) -> FO + Send + Sync + Clone,
@@ -28,7 +28,7 @@ fn par_filtermap_fil_cnt<I, FO, Out, FilterMap, Fil>(
     filter: Fil,
 ) -> usize
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     FO: Fallible<Out> + Send + Sync,
     Out: Send + Sync,
     FilterMap: Fn(I::Item) -> FO + Send + Sync + Clone,
@@ -48,7 +48,7 @@ fn task<I, FO, Out, FilterMap, Fil>(
     chunk_size: usize,
 ) -> usize
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     FO: Fallible<Out> + Send + Sync,
     Out: Send + Sync,
     FilterMap: Fn(I::Item) -> FO + Send + Sync + Clone,
@@ -81,9 +81,8 @@ where
         }
         c => {
             let mut acc = 0;
-            while let Some(chunk) = iter.next_chunk(c) {
+            while let Some(chunk) = iter.next_chunk_x(c) {
                 let x = chunk
-                    .values
                     .map(filter_map)
                     .filter(|x| x.has_value())
                     .map(|x| x.value())
@@ -102,7 +101,7 @@ fn seq_filtermap_fil_cnt<I, FO, Out, FilterMap, Fil>(
     filter: Fil,
 ) -> usize
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     FO: Fallible<Out> + Send + Sync,
     Out: Send + Sync,
     FilterMap: Fn(I::Item) -> FO + Send + Sync,

--- a/src/core/filtermap_fil_col.rs
+++ b/src/core/filtermap_fil_col.rs
@@ -1,7 +1,7 @@
 use super::map_fil_col::{heap_sort_into_pinned_vec, heap_sort_into_vec};
 use super::runner::{ParTask, Runner};
 use crate::{Fallible, Params};
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::{ConcurrentIter, ConcurrentIterX};
 use orx_fixed_vec::PinnedVec;
 
 fn task<I, FO, Out, FilterMap, Fil>(
@@ -114,7 +114,7 @@ pub fn seq_filtermap_fil_col_pinned_vec<I, FO, Out, FilterMap, Fil, P>(
     filter: Fil,
     output: &mut P,
 ) where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     FO: Fallible<Out> + Send + Sync,
     Out: Send + Sync,
     FilterMap: Fn(I::Item) -> FO + Send + Sync,

--- a/src/core/filtermap_fil_col_x.rs
+++ b/src/core/filtermap_fil_col_x.rs
@@ -1,6 +1,6 @@
 use super::runner::{ParTask, Runner};
 use crate::{Fallible, Params};
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::ConcurrentIterX;
 use orx_split_vec::{Recursive, SplitVec};
 
 fn task<I, FO, Out, FilterMap, Fil>(
@@ -10,7 +10,7 @@ fn task<I, FO, Out, FilterMap, Fil>(
     chunk_size: usize,
 ) -> Vec<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     FO: Fallible<Out> + Send + Sync,
     Out: Send + Sync,
     FilterMap: Fn(I::Item) -> FO + Send + Sync,
@@ -26,10 +26,9 @@ where
             .collect(),
         c => {
             let mut collected = vec![];
-            while let Some(chunk) = iter.next_chunk(c) {
+            while let Some(chunk) = iter.next_chunk_x(c) {
                 collected.extend(
                     chunk
-                        .values
                         .map(&filter_map)
                         .filter(|x| x.has_value())
                         .map(|x| x.value())
@@ -48,7 +47,7 @@ pub fn par_filtermap_fil_col_x_rec<I, FO, Out, FilterMap, Fil>(
     filter: Fil,
     output: &mut SplitVec<Out, Recursive>,
 ) where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     FO: Fallible<Out> + Send + Sync,
     Out: Send + Sync,
     FilterMap: Fn(I::Item) -> FO + Send + Sync,

--- a/src/core/filtermap_fil_find.rs
+++ b/src/core/filtermap_fil_find.rs
@@ -1,7 +1,7 @@
 use super::runner::{ParTask, Runner};
 use crate::core::utils::maybe_reduce;
 use crate::{Fallible, Params};
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::{ConcurrentIter, ConcurrentIterX};
 
 pub fn filtermap_fil_find<I, FO, Out, FilterMap, Fil>(
     params: Params,
@@ -112,7 +112,7 @@ fn seq_filtermap_fil_find<I, FO, Out, FilterMap, Fil>(
     filter: Fil,
 ) -> Option<(usize, Out)>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     FO: Fallible<Out> + Send + Sync,
     Out: Send + Sync,
     FilterMap: Fn(I::Item) -> FO + Send + Sync,

--- a/src/core/filtermap_fil_red.rs
+++ b/src/core/filtermap_fil_red.rs
@@ -1,7 +1,7 @@
 use super::runner::{ParTask, Runner};
 use super::utils::maybe_reduce;
 use crate::{Fallible, Params};
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::ConcurrentIterX;
 
 pub fn filtermap_fil_red<I, FO, Out, FilterMap, Fil, Red>(
     params: Params,
@@ -11,7 +11,7 @@ pub fn filtermap_fil_red<I, FO, Out, FilterMap, Fil, Red>(
     reduce: Red,
 ) -> Option<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     FO: Fallible<Out> + Send + Sync,
     Out: Send + Sync,
     FilterMap: Fn(I::Item) -> FO + Send + Sync + Clone,
@@ -32,7 +32,7 @@ fn par_filtermap_fil_red<I, FO, Out, FilterMap, Fil, Red>(
     reduce: Red,
 ) -> Option<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     FO: Fallible<Out> + Send + Sync,
     Out: Send + Sync,
     FilterMap: Fn(I::Item) -> FO + Send + Sync + Clone,
@@ -55,7 +55,7 @@ fn task<I, FO, Out, FilterMap, Fil, Red>(
     chunk_size: usize,
 ) -> Option<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     FO: Fallible<Out> + Send + Sync,
     Out: Send + Sync,
     FilterMap: Fn(I::Item) -> FO + Send + Sync + Clone,
@@ -89,10 +89,9 @@ where
         }
         c => {
             let mut acc = None;
-            let mut buffered = iter.buffered_iter(c);
-            while let Some(chunk) = buffered.next() {
+            let mut buffered = iter.buffered_iter_x(c);
+            while let Some(chunk) = buffered.next_x() {
                 let x = chunk
-                    .values
                     .map(filter_map)
                     .filter(|x| x.has_value())
                     .map(|x| x.value())
@@ -112,7 +111,7 @@ fn seq_filtermap_fil_red<I, FO, Out, FilterMap, Fil, Red>(
     reduce: Red,
 ) -> Option<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     FO: Fallible<Out> + Send + Sync,
     Out: Send + Sync,
     FilterMap: Fn(I::Item) -> FO + Send + Sync,

--- a/src/core/flatmap_fil_cnt.rs
+++ b/src/core/flatmap_fil_cnt.rs
@@ -1,6 +1,6 @@
 use super::runner::{ParTask, Runner};
 use crate::Params;
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::ConcurrentIterX;
 
 pub fn fmap_fil_cnt<I, OutIter, Out, Map, Fil>(
     params: Params,
@@ -9,7 +9,7 @@ pub fn fmap_fil_cnt<I, OutIter, Out, Map, Fil>(
     filter: Fil,
 ) -> usize
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     OutIter: IntoIterator<Item = Out>,
     Out: Send + Sync,
     Map: Fn(I::Item) -> OutIter + Send + Sync,
@@ -28,7 +28,7 @@ fn par_fmap_fil_cnt<I, OutIter, Out, Map, Fil>(
     filter: Fil,
 ) -> usize
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     OutIter: IntoIterator<Item = Out>,
     Out: Send + Sync,
     Map: Fn(I::Item) -> OutIter + Send + Sync,
@@ -43,7 +43,7 @@ where
 
 fn task<I, OutIter, Out, Map, Fil>(iter: &I, map: &Map, filter: &Fil, chunk_size: usize) -> usize
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     OutIter: IntoIterator<Item = Out>,
     Out: Send + Sync,
     Map: Fn(I::Item) -> OutIter + Send + Sync,
@@ -53,8 +53,8 @@ where
         1 => iter.values().flat_map(&map).filter(&filter).count(),
         c => {
             let mut count = 0;
-            while let Some(chunk) = iter.next_chunk(c) {
-                count += chunk.values.flat_map(&map).filter(&filter).count();
+            while let Some(chunk) = iter.next_chunk_x(c) {
+                count += chunk.flat_map(&map).filter(&filter).count();
             }
             count
         }
@@ -63,7 +63,7 @@ where
 
 fn seq_fmap_fil_cnt<I, OutIter, Out, Map, Fil>(iter: I, fmap: Map, filter: Fil) -> usize
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     OutIter: IntoIterator<Item = Out>,
     Out: Send + Sync,
     Map: Fn(I::Item) -> OutIter + Send + Sync,

--- a/src/core/flatmap_fil_col.rs
+++ b/src/core/flatmap_fil_col.rs
@@ -1,7 +1,7 @@
 use super::map_fil_col::{heap_sort_into_pinned_vec, heap_sort_into_vec};
 use super::runner::{ParTask, Runner};
 use crate::Params;
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::{ConcurrentIter, ConcurrentIterX};
 use orx_fixed_vec::PinnedVec;
 
 fn task<I, OutIter, Out, FlatMap, Fil>(
@@ -91,7 +91,7 @@ pub fn seq_flatmap_fil_col_vec<I, OutIter, Out, FlatMap, Fil>(
     filter: Fil,
     output: &mut Vec<Out>,
 ) where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     OutIter: IntoIterator<Item = Out>,
     Out: Send + Sync,
     FlatMap: Fn(I::Item) -> OutIter + Send + Sync,
@@ -109,7 +109,7 @@ pub fn seq_flatmap_fil_col_pinned_vec<I, OutIter, Out, FlatMap, Fil, P>(
     filter: Fil,
     output: &mut P,
 ) where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     OutIter: IntoIterator<Item = Out>,
     Out: Send + Sync,
     FlatMap: Fn(I::Item) -> OutIter + Send + Sync,

--- a/src/core/flatmap_fil_col_x.rs
+++ b/src/core/flatmap_fil_col_x.rs
@@ -1,6 +1,6 @@
 use super::runner::{ParTask, Runner};
 use crate::Params;
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::ConcurrentIterX;
 use orx_split_vec::{Recursive, SplitVec};
 
 fn task<I, OutIter, Out, FlatMap, Fil>(
@@ -10,7 +10,7 @@ fn task<I, OutIter, Out, FlatMap, Fil>(
     chunk_size: usize,
 ) -> Vec<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     OutIter: IntoIterator<Item = Out>,
     Out: Send + Sync,
     FlatMap: Fn(I::Item) -> OutIter + Send + Sync,
@@ -20,8 +20,8 @@ where
         1 => iter.values().flat_map(&flat_map).filter(&filter).collect(),
         c => {
             let mut collected = vec![];
-            while let Some(chunk) = iter.next_chunk(c) {
-                collected.extend(chunk.values.flat_map(&flat_map).filter(&filter));
+            while let Some(chunk) = iter.next_chunk_x(c) {
+                collected.extend(chunk.flat_map(&flat_map).filter(&filter));
             }
             collected
         }
@@ -35,7 +35,7 @@ pub fn par_flatmap_fil_col_x_rec<I, OutIter, Out, FlatMap, Fil>(
     filter: Fil,
     output: &mut SplitVec<Out, Recursive>,
 ) where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     OutIter: IntoIterator<Item = Out>,
     Out: Send + Sync,
     FlatMap: Fn(I::Item) -> OutIter + Send + Sync,

--- a/src/core/flatmap_fil_find.rs
+++ b/src/core/flatmap_fil_find.rs
@@ -1,7 +1,7 @@
 use super::runner::{ParTask, Runner};
 use crate::core::utils::maybe_reduce;
 use crate::Params;
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::{ConcurrentIter, ConcurrentIterX};
 
 pub fn fmap_fil_find<I, OutIter, Out, Map, Fil>(
     params: Params,
@@ -96,7 +96,7 @@ where
 
 fn seq_fmap_fil_find<I, OutIter, Out, Map, Fil>(iter: I, map: Map, filter: Fil) -> Option<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     OutIter: IntoIterator<Item = Out>,
     Out: Send + Sync,
     Map: Fn(I::Item) -> OutIter + Send + Sync,

--- a/src/core/flatmap_fil_red.rs
+++ b/src/core/flatmap_fil_red.rs
@@ -1,7 +1,7 @@
 use super::runner::{ParTask, Runner};
 use super::utils::maybe_reduce;
 use crate::Params;
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::ConcurrentIterX;
 
 pub fn fmap_fil_red<I, OutIter, Out, Map, Fil, Red>(
     params: Params,
@@ -11,7 +11,7 @@ pub fn fmap_fil_red<I, OutIter, Out, Map, Fil, Red>(
     reduce: Red,
 ) -> Option<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     OutIter: IntoIterator<Item = Out>,
     Out: Send + Sync,
     Map: Fn(I::Item) -> OutIter + Send + Sync,
@@ -32,7 +32,7 @@ fn par_fmap_fil_red<I, OutIter, Out, Map, Fil, Red>(
     reduce: Red,
 ) -> Option<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     OutIter: IntoIterator<Item = Out>,
     Out: Send + Sync,
     Map: Fn(I::Item) -> OutIter + Send + Sync,
@@ -55,7 +55,7 @@ fn task<I, OutIter, Out, Map, Fil, Red>(
     chunk_size: usize,
 ) -> Option<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     OutIter: IntoIterator<Item = Out>,
     Out: Send + Sync,
     Map: Fn(I::Item) -> OutIter + Send + Sync,
@@ -66,9 +66,9 @@ where
         1 => iter.values().flat_map(fmap).filter(filter).reduce(reduce),
         c => {
             let mut acc = None;
-            let mut buffered = iter.buffered_iter(c);
-            while let Some(chunk) = buffered.next() {
-                let x = chunk.values.flat_map(fmap).filter(filter).reduce(reduce);
+            let mut buffered = iter.buffered_iter_x(c);
+            while let Some(chunk) = buffered.next_x() {
+                let x = chunk.flat_map(fmap).filter(filter).reduce(reduce);
                 acc = maybe_reduce(reduce, acc, x);
             }
             acc
@@ -83,7 +83,7 @@ fn seq_fmap_fil_red<I, OutIter, Out, Map, Fil, Red>(
     reduce: Red,
 ) -> Option<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     OutIter: IntoIterator<Item = Out>,
     Out: Send + Sync,
     Map: Fn(I::Item) -> OutIter,

--- a/src/core/map_col.rs
+++ b/src/core/map_col.rs
@@ -1,6 +1,6 @@
 use super::runner::{ParTask, Runner};
 use crate::Params;
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::{ConcurrentIter, ConcurrentIterX};
 use orx_concurrent_ordered_bag::ConcurrentOrderedBag;
 use orx_pinned_vec::IntoConcurrentPinnedVec;
 
@@ -56,7 +56,7 @@ fn task<I, Out, Map, P>(
 
 fn seq_map_col<I, Out, Map, P>(iter: I, map: Map, collected: ConcurrentOrderedBag<Out, P>) -> P
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     Out: Send + Sync,
     Map: Fn(I::Item) -> Out + Send + Sync,
     P: IntoConcurrentPinnedVec<Out>,

--- a/src/core/map_fil_cnt.rs
+++ b/src/core/map_fil_cnt.rs
@@ -1,10 +1,10 @@
 use super::runner::{ParTask, Runner};
 use crate::Params;
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::ConcurrentIterX;
 
 pub fn map_fil_cnt<I, Out, Map, Fil>(params: Params, iter: I, map: Map, filter: Fil) -> usize
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     Out: Send + Sync,
     Map: Fn(I::Item) -> Out + Send + Sync,
     Fil: Fn(&Out) -> bool + Send + Sync,
@@ -17,7 +17,7 @@ where
 
 fn par_map_fil_cnt<I, Out, Map, Fil>(params: Params, iter: I, map: Map, filter: Fil) -> usize
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     Out: Send + Sync,
     Map: Fn(I::Item) -> Out + Send + Sync,
     Fil: Fn(&Out) -> bool + Send + Sync,
@@ -31,7 +31,7 @@ where
 
 fn task<I, Out, Map, Fil>(iter: &I, map: &Map, filter: &Fil, chunk_size: usize) -> usize
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     Out: Send + Sync,
     Map: Fn(I::Item) -> Out + Send + Sync,
     Fil: Fn(&Out) -> bool + Send + Sync,
@@ -40,8 +40,8 @@ where
         1 => iter.values().map(&map).filter(&filter).count(),
         c => {
             let mut count = 0;
-            while let Some(chunk) = iter.next_chunk(c) {
-                count += chunk.values.map(&map).filter(&filter).count();
+            while let Some(chunk) = iter.next_chunk_x(c) {
+                count += chunk.map(&map).filter(&filter).count();
             }
             count
         }
@@ -50,7 +50,7 @@ where
 
 fn seq_map_fil_cnt<I, Out, Map, Fil>(iter: I, map: Map, filter: Fil) -> usize
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     Out: Send + Sync,
     Map: Fn(I::Item) -> Out + Send + Sync,
     Fil: Fn(&Out) -> bool + Send + Sync,

--- a/src/core/map_fil_col.rs
+++ b/src/core/map_fil_col.rs
@@ -1,6 +1,6 @@
 use super::runner::{ParTask, Runner};
 use crate::Params;
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::{ConcurrentIter, ConcurrentIterX};
 use orx_fixed_vec::PinnedVec;
 use orx_priority_queue::{BinaryHeap, PriorityQueue};
 
@@ -137,7 +137,7 @@ pub fn par_map_fil_col_pinned_vec<I, Out, Map, Fil, P>(
 
 pub fn seq_map_fil_col_vec<I, Out, Map, Fil>(iter: I, map: Map, filter: Fil, output: &mut Vec<Out>)
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     Out: Send + Sync,
     Map: Fn(I::Item) -> Out + Send + Sync,
     Fil: Fn(&Out) -> bool + Send + Sync,
@@ -154,7 +154,7 @@ pub fn seq_map_fil_col_pinned_vec<I, Out, Map, Fil, Output>(
     filter: Fil,
     output: &mut Output,
 ) where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     Out: Send + Sync,
     Map: Fn(I::Item) -> Out + Send + Sync,
     Fil: Fn(&Out) -> bool + Send + Sync,

--- a/src/core/map_fil_col_x.rs
+++ b/src/core/map_fil_col_x.rs
@@ -1,11 +1,11 @@
 use super::runner::{ParTask, Runner};
 use crate::Params;
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::ConcurrentIterX;
 use orx_split_vec::{Recursive, SplitVec};
 
 fn task<I, Out, Map, Fil>(iter: &I, map: &Map, filter: &Fil, chunk_size: usize) -> Vec<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     Out: Send + Sync,
     Map: Fn(I::Item) -> Out + Send + Sync,
     Fil: Fn(&Out) -> bool + Send + Sync,
@@ -14,8 +14,8 @@ where
         1 => iter.values().map(&map).filter(&filter).collect(),
         c => {
             let mut collected = vec![];
-            while let Some(chunk) = iter.next_chunk(c) {
-                collected.extend(chunk.values.map(&map).filter(&filter));
+            while let Some(chunk) = iter.next_chunk_x(c) {
+                collected.extend(chunk.map(&map).filter(&filter));
             }
             collected
         }
@@ -29,7 +29,7 @@ pub fn par_map_fil_col_x_rec<I, Out, Map, Fil>(
     filter: Fil,
     output: &mut SplitVec<Out, Recursive>,
 ) where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     Out: Send + Sync,
     Map: Fn(I::Item) -> Out + Send + Sync,
     Fil: Fn(&Out) -> bool + Send + Sync,

--- a/src/core/map_fil_find.rs
+++ b/src/core/map_fil_find.rs
@@ -1,7 +1,7 @@
 use super::runner::{ParTask, Runner};
 use crate::core::utils::maybe_reduce;
 use crate::Params;
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::{ConcurrentIter, ConcurrentIterX};
 
 pub fn map_fil_find<I, Out, Map, Fil>(
     params: Params,
@@ -88,7 +88,7 @@ where
 
 fn seq_map_fil_find<I, Out, Map, Fil>(iter: I, map: Map, filter: Fil) -> Option<(usize, Out)>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     Out: Send + Sync,
     Map: Fn(I::Item) -> Out + Send + Sync,
     Fil: Fn(&Out) -> bool + Send + Sync,

--- a/src/core/map_fil_red.rs
+++ b/src/core/map_fil_red.rs
@@ -1,7 +1,7 @@
 use super::runner::{ParTask, Runner};
 use super::utils::maybe_reduce;
 use crate::Params;
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::ConcurrentIterX;
 
 pub fn map_fil_red<I, Out, Map, Fil, Red>(
     params: Params,
@@ -11,7 +11,7 @@ pub fn map_fil_red<I, Out, Map, Fil, Red>(
     reduce: Red,
 ) -> Option<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     Out: Send + Sync,
     Map: Fn(I::Item) -> Out + Send + Sync,
     Fil: Fn(&Out) -> bool + Send + Sync,
@@ -31,7 +31,7 @@ fn par_map_fil_red<I, Out, Map, Fil, Red>(
     reduce: Red,
 ) -> Option<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     Out: Send + Sync,
     Map: Fn(I::Item) -> Out + Send + Sync,
     Fil: Fn(&Out) -> bool + Send + Sync,
@@ -53,7 +53,7 @@ fn task<I, Out, Map, Fil, Red>(
     chunk_size: usize,
 ) -> Option<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     Out: Send + Sync,
     Map: Fn(I::Item) -> Out + Send + Sync,
     Fil: Fn(&Out) -> bool + Send + Sync,
@@ -63,8 +63,8 @@ where
         1 => iter.values().map(map).filter(filter).reduce(reduce),
         c => {
             let mut acc = None;
-            while let Some(chunk) = iter.next_chunk(c) {
-                let x = chunk.values.map(map).filter(filter).reduce(reduce);
+            while let Some(chunk) = iter.next_chunk_x(c) {
+                let x = chunk.map(map).filter(filter).reduce(reduce);
                 acc = maybe_reduce(reduce, acc, x);
             }
             acc
@@ -79,7 +79,7 @@ fn seq_map_fil_red<I, Out, Map, Fil, Red>(
     reduce: Red,
 ) -> Option<Out>
 where
-    I: ConcurrentIter,
+    I: ConcurrentIterX,
     Out: Send + Sync,
     Map: Fn(I::Item) -> Out + Send + Sync,
     Fil: Fn(&Out) -> bool + Send + Sync,

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -3,7 +3,7 @@ use crate::{
     core::runner_settings::{chunk_size, num_threads},
     Params,
 };
-use orx_concurrent_iter::{ConcurrentIter, HasMore};
+use orx_concurrent_iter::{ConcurrentIterX, HasMore};
 use std::hint::black_box;
 
 const LAG_PERIODICITY: usize = 4;
@@ -93,7 +93,7 @@ impl Runner {
 
     pub fn run<I, F>(params: Params, task_type: ParTask, iter: &I, thread_task: &F) -> usize
     where
-        I: ConcurrentIter,
+        I: ConcurrentIterX,
         F: Fn(usize) + Sync,
     {
         let runner = Self::new(params, task_type, iter.try_get_len());
@@ -134,7 +134,7 @@ impl Runner {
         thread_task: &F,
     ) -> Vec<Out>
     where
-        I: ConcurrentIter,
+        I: ConcurrentIterX,
         F: Fn(usize) -> Out + Sync,
         Out: Send + Sync,
     {
@@ -182,7 +182,7 @@ impl Runner {
         reduce: R,
     ) -> (usize, Option<T>)
     where
-        I: ConcurrentIter,
+        I: ConcurrentIterX,
         F: Fn(usize) -> T + Sync,
         T: Send,
         R: Fn(T, T) -> T,

--- a/src/into/into_par.rs
+++ b/src/into/into_par.rs
@@ -1,5 +1,4 @@
 use crate::par::par_empty::ParEmpty;
-use iter::atomic_iter::AtomicIter;
 use orx_concurrent_iter::*;
 use std::ops::{Add, Range, Sub};
 
@@ -134,9 +133,7 @@ impl<'a, T: Send + Sync> IntoPar for ConIterOfSlice<'a, T> {
 
 // cloned
 
-impl<'a, T: Send + Sync + Clone, C: AtomicIter<&'a T> + ConcurrentIter<Item = &'a T>> IntoPar
-    for Cloned<'a, T, C>
-{
+impl<'a, T: Send + Sync + Clone, C: ConcurrentIter<Item = &'a T>> IntoPar for Cloned<'a, T, C> {
     type ConIter = Cloned<'a, T, C>;
     fn into_par(self) -> ParEmpty<Self::ConIter> {
         ParEmpty::new(self)

--- a/src/into/iter_into_par.rs
+++ b/src/into/iter_into_par.rs
@@ -36,8 +36,9 @@ use orx_concurrent_iter::*;
 ///     .collect_vec();
 /// assert_eq!(par, seq);
 /// ```
-pub trait IterIntoPar<Iter: Iterator>
+pub trait IterIntoPar<Iter>
 where
+    Iter: Iterator,
     Iter::Item: Send + Sync,
 {
     /// Underlying concurrent iterator which provides the input elements to the defined parallel computation.
@@ -83,8 +84,9 @@ where
 
 // iter
 
-impl<Iter: Iterator> IterIntoPar<Iter> for Iter
+impl<Iter> IterIntoPar<Iter> for Iter
 where
+    Iter: Iterator,
     Iter::Item: Send + Sync,
 {
     type ConIter = ConIterOfIter<Iter::Item, Iter>;
@@ -94,8 +96,9 @@ where
     }
 }
 
-impl<Iter: Iterator> IterIntoPar<Iter> for ConIterOfIter<Iter::Item, Iter>
+impl<Iter> IterIntoPar<Iter> for ConIterOfIter<Iter::Item, Iter>
 where
+    Iter: Iterator,
     Iter::Item: Send + Sync,
 {
     type ConIter = ConIterOfIter<Iter::Item, Iter>;

--- a/src/par/par_empty.rs
+++ b/src/par/par_empty.rs
@@ -12,7 +12,7 @@ use crate::{
     ChunkSize, Fallible, NumThreads, ParCollectInto, Params,
 };
 use orx_concurrent_iter::ConcurrentIter;
-use orx_split_vec::SplitVec;
+use orx_split_vec::{Growth, SplitVec};
 
 /// A parallel iterator.
 ///
@@ -120,6 +120,10 @@ where
 
     fn collect_into<C: ParCollectInto<Self::Item>>(self, output: C) -> C {
         output.seq_extend(self.iter.into_seq_iter())
+    }
+
+    fn collect_x(self) -> SplitVec<Self::Item, impl Growth> {
+        self.collect()
     }
 }
 

--- a/src/par/par_empty.rs
+++ b/src/par/par_empty.rs
@@ -86,12 +86,12 @@ where
     where
         R: Fn(Self::Item, Self::Item) -> Self::Item + Send + Sync + Clone,
     {
-        let (params, iter) = (self.params, self.iter.into_concurrent_iter_x());
+        let (params, iter) = (self.params, self.iter.into_con_iter_x());
         map_fil_red(params, iter, map_self, no_filter, reduce)
     }
 
     fn count(self) -> usize {
-        let (params, iter) = (self.params, self.iter.into_concurrent_iter_x());
+        let (params, iter) = (self.params, self.iter.into_con_iter_x());
         map_fil_cnt(params, iter, map_self, no_filter)
     }
 

--- a/src/par/par_empty.rs
+++ b/src/par/par_empty.rs
@@ -86,11 +86,12 @@ where
     where
         R: Fn(Self::Item, Self::Item) -> Self::Item + Send + Sync + Clone,
     {
-        map_fil_red(self.params, self.iter, map_self, no_filter, reduce)
+        let (params, iter) = (self.params, self.iter.into_concurrent_iter_x());
+        map_fil_red(params, iter, map_self, no_filter, reduce)
     }
 
     fn count(self) -> usize {
-        let (params, iter) = (self.params, self.iter);
+        let (params, iter) = (self.params, self.iter.into_concurrent_iter_x());
         map_fil_cnt(params, iter, map_self, no_filter)
     }
 

--- a/src/par/par_fil.rs
+++ b/src/par/par_fil.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     Fallible, Par, ParCollectInto, Params,
 };
-use orx_concurrent_iter::{ConIterOfVec, ConcurrentIter, IntoConcurrentIter};
+use orx_concurrent_iter::{ConIterOfVec, ConcurrentIter, ConcurrentIterX, IntoConcurrentIter};
 use orx_split_vec::SplitVec;
 
 /// A parallel iterator.
@@ -52,7 +52,7 @@ where
         I,
         Option<O>,
         O,
-        impl Fn(<I as ConcurrentIter>::Item) -> Option<O> + Send + Sync + Clone,
+        impl Fn(<I as ConcurrentIterX>::Item) -> Option<O> + Send + Sync + Clone,
     >
     where
         O: Send + Sync,
@@ -69,7 +69,7 @@ where
     fn flat_map<O, OI, FM>(
         self,
         flat_map: FM,
-    ) -> ParFlatMap<ConIterOfVec<<I as ConcurrentIter>::Item>, O, OI, FM>
+    ) -> ParFlatMap<ConIterOfVec<<I as ConcurrentIterX>::Item>, O, OI, FM>
     where
         O: Send + Sync,
         OI: IntoIterator<Item = O>,
@@ -97,7 +97,7 @@ where
         I,
         Option<O>,
         O,
-        impl Fn(<I as ConcurrentIter>::Item) -> Option<O> + Send + Sync + Clone,
+        impl Fn(<I as ConcurrentIterX>::Item) -> Option<O> + Send + Sync + Clone,
     >
     where
         O: Send + Sync,

--- a/src/par/par_fil.rs
+++ b/src/par/par_fil.rs
@@ -32,7 +32,7 @@ where
     }
 
     fn destruct_x(self) -> (Params, impl ConcurrentIterX<Item = I::Item>, F) {
-        (self.params, self.iter.into_concurrent_iter_x(), self.filter)
+        (self.params, self.iter.into_con_iter_x(), self.filter)
     }
 }
 

--- a/src/par/par_fil.rs
+++ b/src/par/par_fil.rs
@@ -7,7 +7,7 @@ use crate::{
     Fallible, Par, ParCollectInto, Params,
 };
 use orx_concurrent_iter::{ConIterOfVec, ConcurrentIter, ConcurrentIterX, IntoConcurrentIter};
-use orx_split_vec::SplitVec;
+use orx_split_vec::{Growth, SplitVec};
 
 /// A parallel iterator.
 ///
@@ -156,15 +156,23 @@ where
     // collect
 
     fn collect_vec(self) -> Vec<Self::Item> {
-        ParMapFilter::new(self.iter, self.params, map_self, self.filter).collect_vec()
+        let (params, iter, filter) = self.destruct();
+        ParMapFilter::new(iter, params, map_self, filter).collect_vec()
     }
 
     fn collect(self) -> SplitVec<Self::Item> {
-        ParMapFilter::new(self.iter, self.params, map_self, self.filter).collect()
+        let (params, iter, filter) = self.destruct();
+        ParMapFilter::new(iter, params, map_self, filter).collect()
     }
 
     fn collect_into<C: ParCollectInto<Self::Item>>(self, output: C) -> C {
-        ParMapFilter::new(self.iter, self.params, map_self, self.filter).collect_into(output)
+        let (params, iter, filter) = self.destruct();
+        ParMapFilter::new(iter, params, map_self, filter).collect_into(output)
+    }
+
+    fn collect_x(self) -> SplitVec<Self::Item, impl Growth> {
+        let (params, iter, filter) = self.destruct();
+        ParMapFilter::new(iter, params, map_self, filter).collect_x()
     }
 }
 

--- a/src/par/par_filtermap.rs
+++ b/src/par/par_filtermap.rs
@@ -3,7 +3,7 @@ use crate::{
     core::default_fns::no_filter, ChunkSize, Fallible, NumThreads, Par, ParCollectInto, Params,
 };
 use orx_concurrent_iter::{ConcurrentIter, ConcurrentIterX, IntoConcurrentIter};
-use orx_split_vec::{Recursive, SplitVec};
+use orx_split_vec::{Growth, SplitVec};
 use std::marker::PhantomData;
 
 /// A parallel iterator.
@@ -175,7 +175,7 @@ where
         self.filter(no_filter).collect_into(output)
     }
 
-    fn collect_x(self) -> SplitVec<Self::Item, Recursive> {
+    fn collect_x(self) -> SplitVec<Self::Item, impl Growth> {
         self.filter(no_filter).collect_x()
     }
 }

--- a/src/par/par_filtermap.rs
+++ b/src/par/par_filtermap.rs
@@ -1,8 +1,8 @@
 use super::{par_filtermap_fil::ParFilterMapFilter, par_flatmap::ParFlatMap};
 use crate::{
-    core::default_fns::no_filter, ChunkSize, Fallible, NumThreads, ParCollectInto, Par, Params,
+    core::default_fns::no_filter, ChunkSize, Fallible, NumThreads, Par, ParCollectInto, Params,
 };
-use orx_concurrent_iter::{ConcurrentIter, IntoConcurrentIter};
+use orx_concurrent_iter::{ConcurrentIter, ConcurrentIterX, IntoConcurrentIter};
 use orx_split_vec::{Recursive, SplitVec};
 use std::marker::PhantomData;
 
@@ -75,7 +75,7 @@ where
         I,
         Option<O2>,
         O2,
-        impl Fn(<I as ConcurrentIter>::Item) -> Option<O2> + Send + Sync + Clone,
+        impl Fn(<I as ConcurrentIterX>::Item) -> Option<O2> + Send + Sync + Clone,
     >
     where
         O2: Send + Sync,
@@ -113,7 +113,7 @@ where
         I,
         Option<O2>,
         O2,
-        impl Fn(<I as ConcurrentIter>::Item) -> Option<O2> + Send + Sync + Clone,
+        impl Fn(<I as ConcurrentIterX>::Item) -> Option<O2> + Send + Sync + Clone,
     >
     where
         O2: Send + Sync,

--- a/src/par/par_filtermap_fil.rs
+++ b/src/par/par_filtermap_fil.rs
@@ -240,7 +240,7 @@ where
             true => SplitVec::from(self.collect()),
             false => {
                 let mut recursive = SplitVec::with_recursive_growth();
-                let (params, iter, map, filter) = self.destruct();
+                let (params, iter, map, filter) = self.destruct_x();
                 par_filtermap_fil_col_x_rec(params, iter, map, filter, &mut recursive);
                 recursive
             }

--- a/src/par/par_filtermap_fil.rs
+++ b/src/par/par_filtermap_fil.rs
@@ -7,9 +7,9 @@ use crate::{
         filtermap_fil_cnt::filtermap_fil_cnt, filtermap_fil_col_x::par_filtermap_fil_col_x_rec,
         filtermap_fil_find::filtermap_fil_find, filtermap_fil_red::filtermap_fil_red,
     },
-    ChunkSize, Fallible, NumThreads, ParCollectInto, Par, Params,
+    ChunkSize, Fallible, NumThreads, Par, ParCollectInto, Params,
 };
-use orx_concurrent_iter::{ConIterOfVec, ConcurrentIter, IntoConcurrentIter};
+use orx_concurrent_iter::{ConIterOfVec, ConcurrentIter, ConcurrentIterX, IntoConcurrentIter};
 use orx_split_vec::{Recursive, SplitVec};
 use std::marker::PhantomData;
 
@@ -103,7 +103,7 @@ where
         I,
         Option<O2>,
         O2,
-        impl Fn(<I as ConcurrentIter>::Item) -> Option<O2> + Send + Sync + Clone,
+        impl Fn(<I as ConcurrentIterX>::Item) -> Option<O2> + Send + Sync + Clone,
     >
     where
         O2: Send + Sync,
@@ -159,7 +159,7 @@ where
         I,
         Option<O2>,
         O2,
-        impl Fn(<I as ConcurrentIter>::Item) -> Option<O2> + Send + Sync + Clone,
+        impl Fn(<I as ConcurrentIterX>::Item) -> Option<O2> + Send + Sync + Clone,
     >
     where
         O2: Send + Sync,

--- a/src/par/par_filtermap_fil.rs
+++ b/src/par/par_filtermap_fil.rs
@@ -53,6 +53,15 @@ where
         (self.params, self.iter, self.filter_map, self.filter)
     }
 
+    pub(crate) fn destruct_x(self) -> (Params, impl ConcurrentIterX<Item = I::Item>, M, F) {
+        (
+            self.params,
+            self.iter.into_concurrent_iter_x(),
+            self.filter_map,
+            self.filter,
+        )
+    }
+
     // find
 
     pub fn first_with_index(self) -> Option<(usize, O)> {
@@ -190,12 +199,13 @@ where
     where
         R: Fn(Self::Item, Self::Item) -> Self::Item + Send + Sync + Clone,
     {
-        filtermap_fil_red(self.params, self.iter, self.filter_map, self.filter, reduce)
+        let (params, iter, filter_map, filter) = self.destruct_x();
+        filtermap_fil_red(params, iter, filter_map, filter, reduce)
     }
 
     fn count(self) -> usize {
-        let (params, iter, map, filter) = (self.params, self.iter, self.filter_map, self.filter);
-        filtermap_fil_cnt(params, iter, map, filter)
+        let (params, iter, filter_map, filter) = self.destruct_x();
+        filtermap_fil_cnt(params, iter, filter_map, filter)
     }
 
     // find

--- a/src/par/par_filtermap_fil.rs
+++ b/src/par/par_filtermap_fil.rs
@@ -56,7 +56,7 @@ where
     pub(crate) fn destruct_x(self) -> (Params, impl ConcurrentIterX<Item = I::Item>, M, F) {
         (
             self.params,
-            self.iter.into_concurrent_iter_x(),
+            self.iter.into_con_iter_x(),
             self.filter_map,
             self.filter,
         )

--- a/src/par/par_flatmap.rs
+++ b/src/par/par_flatmap.rs
@@ -2,7 +2,7 @@ use super::par_filtermap::ParFilterMap;
 use super::par_flatmap_fil::ParFlatMapFilter;
 use crate::{core::default_fns::no_filter, Params};
 use crate::{Fallible, Par, ParCollectInto};
-use orx_concurrent_iter::{ConIterOfVec, ConcurrentIter};
+use orx_concurrent_iter::{ConIterOfVec, ConcurrentIter, ConcurrentIterX};
 use orx_split_vec::{Recursive, SplitVec};
 use std::iter::Map;
 
@@ -73,7 +73,7 @@ where
         I,
         O2,
         Map<<OI as IntoIterator>::IntoIter, M2>,
-        impl Fn(<I as ConcurrentIter>::Item) -> Map<<OI as IntoIterator>::IntoIter, M2> + Clone,
+        impl Fn(<I as ConcurrentIterX>::Item) -> Map<<OI as IntoIterator>::IntoIter, M2> + Clone,
     >
     where
         O2: Send + Sync,

--- a/src/par/par_flatmap_fil.rs
+++ b/src/par/par_flatmap_fil.rs
@@ -53,7 +53,7 @@ where
     pub(crate) fn destruct_x(self) -> (Params, impl ConcurrentIterX<Item = I::Item>, M, F) {
         (
             self.params,
-            self.iter.into_concurrent_iter_x(),
+            self.iter.into_con_iter_x(),
             self.flat_map,
             self.filter,
         )

--- a/src/par/par_flatmap_fil.rs
+++ b/src/par/par_flatmap_fil.rs
@@ -183,7 +183,7 @@ where
             true => SplitVec::from(self.collect()),
             false => {
                 let mut recursive = SplitVec::with_recursive_growth();
-                let (params, iter, map, filter) = self.destruct();
+                let (params, iter, map, filter) = self.destruct_x();
                 par_flatmap_fil_col_x_rec(params, iter, map, filter, &mut recursive);
                 recursive
             }

--- a/src/par/par_map.rs
+++ b/src/par/par_map.rs
@@ -10,7 +10,7 @@ use crate::{
     par_iter::Par,
     Fallible, ParCollectInto, Params,
 };
-use orx_concurrent_iter::ConcurrentIter;
+use orx_concurrent_iter::{ConcurrentIter, ConcurrentIterX};
 use orx_split_vec::{Recursive, SplitVec};
 
 /// A parallel iterator.
@@ -170,7 +170,7 @@ where
     fn flat_map<O2, OI, FM>(
         self,
         flat_map: FM,
-    ) -> ParFlatMap<I, O2, OI, impl Fn(<I as ConcurrentIter>::Item) -> OI + Clone>
+    ) -> ParFlatMap<I, O2, OI, impl Fn(<I as ConcurrentIterX>::Item) -> OI + Clone>
     where
         O2: Send + Sync,
         OI: IntoIterator<Item = O2>,
@@ -191,7 +191,7 @@ where
     fn filter_map<O2, FO, FM>(
         self,
         filter_map: FM,
-    ) -> ParFilterMap<I, FO, O2, impl Fn(<I as ConcurrentIter>::Item) -> FO + Send + Sync + Clone>
+    ) -> ParFilterMap<I, FO, O2, impl Fn(<I as ConcurrentIterX>::Item) -> FO + Send + Sync + Clone>
     where
         O2: Send + Sync,
         FO: Fallible<O2> + Send + Sync,

--- a/src/par/par_map.rs
+++ b/src/par/par_map.rs
@@ -41,6 +41,10 @@ where
         (self.params, self.iter, self.map)
     }
 
+    pub(crate) fn destruct_x(self) -> (Params, impl ConcurrentIterX<Item = I::Item>, M) {
+        (self.params, self.iter.into_concurrent_iter_x(), self.map)
+    }
+
     pub(crate) fn iter_len(&self) -> Option<usize> {
         self.iter.try_get_len()
     }
@@ -208,11 +212,12 @@ where
     where
         R: Fn(Self::Item, Self::Item) -> Self::Item + Send + Sync + Clone,
     {
-        map_fil_red(self.params, self.iter, self.map, no_filter, reduce)
+        let (params, iter, map) = self.destruct_x();
+        map_fil_red(params, iter, map, no_filter, reduce)
     }
 
     fn count(self) -> usize {
-        let (params, iter, map) = self.destruct();
+        let (params, iter, map) = self.destruct_x();
         map_fil_cnt(params, iter, map, no_filter)
     }
 

--- a/src/par/par_map.rs
+++ b/src/par/par_map.rs
@@ -42,7 +42,7 @@ where
     }
 
     pub(crate) fn destruct_x(self) -> (Params, impl ConcurrentIterX<Item = I::Item>, M) {
-        (self.params, self.iter.into_concurrent_iter_x(), self.map)
+        (self.params, self.iter.into_con_iter_x(), self.map)
     }
 
     pub(crate) fn iter_len(&self) -> Option<usize> {

--- a/src/par/par_map_fil.rs
+++ b/src/par/par_map_fil.rs
@@ -48,6 +48,15 @@ where
         (self.params, self.iter, self.map, self.filter)
     }
 
+    pub(crate) fn destruct_x(self) -> (Params, impl ConcurrentIterX<Item = I::Item>, M, F) {
+        (
+            self.params,
+            self.iter.into_concurrent_iter_x(),
+            self.map,
+            self.filter,
+        )
+    }
+
     // find
 
     /// Returns the first element of the iterator; returns None if the iterator is empty.
@@ -243,11 +252,12 @@ where
     where
         R: Fn(Self::Item, Self::Item) -> Self::Item + Send + Sync + Clone,
     {
-        map_fil_red(self.params, self.iter, self.map, self.filter, reduce)
+        let (params, iter, map, filter) = self.destruct_x();
+        map_fil_red(params, iter, map, filter, reduce)
     }
 
     fn count(self) -> usize {
-        let (params, iter, map, filter) = self.destruct();
+        let (params, iter, map, filter) = self.destruct_x();
         map_fil_cnt(params, iter, map, filter)
     }
 

--- a/src/par/par_map_fil.rs
+++ b/src/par/par_map_fil.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     Fallible, Par, ParCollectInto, Params,
 };
-use orx_concurrent_iter::{ConIterOfVec, ConcurrentIter, IntoConcurrentIter};
+use orx_concurrent_iter::{ConIterOfVec, ConcurrentIter, ConcurrentIterX, IntoConcurrentIter};
 use orx_split_vec::{Recursive, SplitVec};
 
 /// A parallel iterator.
@@ -169,7 +169,7 @@ where
         I,
         Option<O2>,
         O2,
-        impl Fn(<I as ConcurrentIter>::Item) -> Option<O2> + Send + Sync + Clone,
+        impl Fn(<I as ConcurrentIterX>::Item) -> Option<O2> + Send + Sync + Clone,
     >
     where
         O2: Send + Sync,
@@ -219,7 +219,7 @@ where
         I,
         Option<O2>,
         O2,
-        impl Fn(<I as ConcurrentIter>::Item) -> Option<O2> + Send + Sync + Clone,
+        impl Fn(<I as ConcurrentIterX>::Item) -> Option<O2> + Send + Sync + Clone,
     >
     where
         O2: Send + Sync,

--- a/src/par/par_map_fil.rs
+++ b/src/par/par_map_fil.rs
@@ -51,7 +51,7 @@ where
     pub(crate) fn destruct_x(self) -> (Params, impl ConcurrentIterX<Item = I::Item>, M, F) {
         (
             self.params,
-            self.iter.into_concurrent_iter_x(),
+            self.iter.into_con_iter_x(),
             self.map,
             self.filter,
         )

--- a/src/par/par_map_fil.rs
+++ b/src/par/par_map_fil.rs
@@ -294,7 +294,7 @@ where
             true => SplitVec::from(self.collect()),
             false => {
                 let mut recursive = SplitVec::with_recursive_growth();
-                let (params, iter, map, filter) = self.destruct();
+                let (params, iter, map, filter) = self.destruct_x();
                 par_map_fil_col_x_rec(params, iter, map, filter, &mut recursive);
                 recursive
             }

--- a/src/par_iter.rs
+++ b/src/par_iter.rs
@@ -1,5 +1,5 @@
 use crate::{ChunkSize, Fallible, NumThreads, ParCollectInto, Params};
-use orx_split_vec::{Recursive, SplitVec};
+use orx_split_vec::{Growth, SplitVec};
 use std::{cmp::Ordering, ops::Add};
 
 /// An iterator used to define a computation that can be executed in parallel.
@@ -531,9 +531,7 @@ where
     /// sorted_output.sort(); // WIP: PinnedVec::sort(&mut self)
     /// assert_eq!(sorted_output, vec![1, 2, 2, 3, 3, 3, 4, 4, 4, 4]);
     /// ```
-    fn collect_x(self) -> SplitVec<Self::Item, Recursive> {
-        self.collect().into()
-    }
+    fn collect_x(self) -> SplitVec<Self::Item, impl Growth>;
 
     // reduced - provided
 


### PR DESCRIPTION
# Unordered iteration is revisited

* Upgraded the dependency to concurrent iterator to 1.27.0; see the [release notes](https://github.com/orxfun/orx-concurrent-iter/releases/tag/1.27.0).
* Syntax for creating a parallel iterator from a sequential iterator is fixed.
  * prior: `inputs.into_con_iter().into_par()`.
  * new: `inputs.iter().par()`
* Parallel reductions use transformation into `ConcurrentIterX` to have the performance benefits whenever possible.
* `collect_x` executions use transformation into `ConcurrentIterX` to have the performance benefits whenever possible.