### PR TITLE
Upgrade concurrent iterator dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-parallel"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 readme = "README.md"
@@ -12,15 +12,15 @@ categories = ["concurrency", "algorithms"]
 
 [dependencies]
 orx-pseudo-default = { version = "2.1.0", default-features = false }
-orx-pinned-vec = "3.16.0"
-orx-fixed-vec = "3.16.0"
-orx-split-vec = "3.16.0"
+orx-pinned-vec = { version = "3.16.0", default-features = false }
+orx-fixed-vec = { version = "3.17.0", default-features = false }
+orx-split-vec = { version = "3.17.0", default-features = false }
 orx-pinned-concurrent-col = "2.13.0"
 orx-concurrent-bag = "2.12.0"
 orx-concurrent-ordered-bag = "2.12.0"
 orx-iterable = "1.3.0"
 orx-priority-queue = "1.7.0"
-orx-concurrent-iter = "2.0.0"
+orx-concurrent-iter = "2.1.0"
 rayon = { version = "1.10.0", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -72,14 +72,22 @@ Inputs that can be used in parallel computations can be categorized in three gro
 
 These are collections which are parallelized by utilizing their specific structure to achieve high performance.
 
-**orx-parallel** crate provides direct implementations of std collections. Implementations of custom collections must belong to the respective crates as they most likely require to access the internals. The following is the most recent table of direct implementations.
+This crate provides direct implementations of std collections; the table below lists the most recent table of direct implementations.
 
 
 | Type | Over References<br>`-> ParIter<Item = &T>` | Over Owned Values<br>`-> ParIter<Item = T>` |
 |---|---|---|
 | `v: Vec<T>` | `v.par()` | `v.into_par()` |
+| `v: VecDeque<T>` | `v.par()` | `v.into_par()` |
 | `s: &[T]` | `s.par()`<br>`s.into_par()` | |
 | `r: Range<usize>`| | `r.par()`<br>`r.into_par()` |
+
+Implementations of custom collections must belong to the respective crates as they most likely require to access the internals. Currently, the following collections are known to implement [`ParallelizableCollection`](https://docs.rs/orx-parallel/latest/orx_parallel/trait.ParallelizableCollection.html):
+
+| Type | Over References<br>`-> ParIter<Item = &T>` | Over Owned Values<br>`-> ParIter<Item = T>` |
+|---|---|---|
+| [`s: SplitVec<T, G>`](https://crates.io/crates/orx-split-vec) | `s.par()` | `s.into_par()` |
+| [`f: FixedVec<T>`](https://crates.io/crates/orx-fixed-vec) | `f.par()` | `f.into_par()` |
 
 Since these implementations are particularly optimized for the collection type, it is preferable to start defining parallel computation from the collection whenever available. In other words, for a vector `v`,
 

--- a/benches/vec_deque_collect_map_filter.rs
+++ b/benches/vec_deque_collect_map_filter.rs
@@ -1,0 +1,122 @@
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use orx_parallel::*;
+use orx_split_vec::SplitVec;
+use rand::prelude::*;
+use rand_chacha::ChaCha8Rng;
+use rayon::iter::IntoParallelIterator;
+use std::collections::VecDeque;
+
+const TEST_LARGE_OUTPUT: bool = false;
+
+const LARGE_OUTPUT_LEN: usize = match TEST_LARGE_OUTPUT {
+    true => 64,
+    false => 0,
+};
+const SEED: u64 = 5426;
+const FIB_UPPER_BOUND: u32 = 201;
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Output {
+    name: String,
+    numbers: [i64; LARGE_OUTPUT_LEN],
+}
+
+fn map(idx: &usize) -> Output {
+    let idx = *idx;
+    let prefix = match idx % 7 {
+        0 => "zero-",
+        3 => "three-",
+        _ => "sth-",
+    };
+    let fib = fibonacci(&(idx as u32));
+    let name = format!("{}-fib-{}", prefix, fib);
+
+    let mut numbers = [0i64; LARGE_OUTPUT_LEN];
+    for (i, x) in numbers.iter_mut().enumerate() {
+        *x = match (idx * 7 + i) % 3 {
+            0 => idx as i64 + i as i64,
+            _ => idx as i64 - i as i64,
+        };
+    }
+
+    Output { name, numbers }
+}
+
+fn filter(output: &Output) -> bool {
+    let last_char = output.name.chars().last().unwrap();
+    let last_digit: u32 = last_char.to_string().parse().unwrap();
+    last_digit < 4
+}
+
+fn fibonacci(n: &u32) -> u32 {
+    let mut a = 0;
+    let mut b = 1;
+    for _ in 0..*n {
+        let c = a + b;
+        a = b;
+        b = c;
+    }
+    a
+}
+
+fn inputs(len: usize) -> VecDeque<usize> {
+    let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+    (0..len)
+        .map(|_| rng.random_range(0..FIB_UPPER_BOUND) as usize)
+        .collect()
+}
+
+fn seq(inputs: &VecDeque<usize>) -> Vec<Output> {
+    inputs.iter().map(map).filter(filter).collect()
+}
+
+fn rayon(inputs: &VecDeque<usize>) -> Vec<Output> {
+    use rayon::iter::ParallelIterator;
+    inputs.into_par_iter().map(map).filter(filter).collect()
+}
+
+fn orx_into_vec(inputs: &VecDeque<usize>) -> Vec<Output> {
+    inputs.into_par().map(map).filter(filter).collect()
+}
+
+fn orx_into_split_vec(inputs: &VecDeque<usize>) -> SplitVec<Output> {
+    inputs.into_par().map(map).filter(filter).collect()
+}
+
+fn run(c: &mut Criterion) {
+    let treatments = [65_536, 65_536 * 4];
+
+    let mut group = c.benchmark_group("VecDeque: collect_map_filter");
+
+    for n in &treatments {
+        let input = inputs(*n);
+        let expected = seq(&input);
+        let mut sorted = seq(&input);
+        sorted.sort();
+
+        group.bench_with_input(BenchmarkId::new("seq-into-vec", n), n, |b, _| {
+            assert_eq!(&expected, &seq(&input));
+            b.iter(|| seq(black_box(&input)))
+        });
+
+        group.bench_with_input(BenchmarkId::new("rayon-into-vec", n), n, |b, _| {
+            assert_eq!(&expected, &rayon(&input));
+            b.iter(|| rayon(black_box(&input)))
+        });
+
+        group.bench_with_input(BenchmarkId::new("orx-into-vec", n), n, |b, _| {
+            assert_eq!(&expected, &orx_into_vec(&input));
+            b.iter(|| orx_into_vec(black_box(&input)))
+        });
+
+        group.bench_with_input(BenchmarkId::new("orx-into-split-vec", n), n, |b, _| {
+            assert_eq!(&expected, &orx_into_split_vec(&input));
+            b.iter(|| orx_into_split_vec(black_box(&input)))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, run);
+criterion_main!(benches);

--- a/benches/vec_deque_collect_map_filter_owned.rs
+++ b/benches/vec_deque_collect_map_filter_owned.rs
@@ -1,0 +1,122 @@
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use orx_parallel::*;
+use orx_split_vec::SplitVec;
+use rand::prelude::*;
+use rand_chacha::ChaCha8Rng;
+use rayon::iter::IntoParallelIterator;
+use std::collections::VecDeque;
+
+const TEST_LARGE_OUTPUT: bool = false;
+
+const LARGE_OUTPUT_LEN: usize = match TEST_LARGE_OUTPUT {
+    true => 64,
+    false => 0,
+};
+const SEED: u64 = 5426;
+const FIB_UPPER_BOUND: u32 = 201;
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Output {
+    name: String,
+    numbers: [i64; LARGE_OUTPUT_LEN],
+}
+
+fn map(idx: usize) -> Output {
+    let prefix = match idx % 7 {
+        0 => "zero-",
+        3 => "three-",
+        _ => "sth-",
+    };
+    let fib = fibonacci(&(idx as u32));
+    let name = format!("{}-fib-{}", prefix, fib);
+
+    let mut numbers = [0i64; LARGE_OUTPUT_LEN];
+    for (i, x) in numbers.iter_mut().enumerate() {
+        *x = match (idx * 7 + i) % 3 {
+            0 => idx as i64 + i as i64,
+            _ => idx as i64 - i as i64,
+        };
+    }
+
+    Output { name, numbers }
+}
+
+fn filter(output: &Output) -> bool {
+    let last_char = output.name.chars().last().unwrap();
+    let last_digit: u32 = last_char.to_string().parse().unwrap();
+    last_digit < 4
+}
+
+fn fibonacci(n: &u32) -> u32 {
+    let mut a = 0;
+    let mut b = 1;
+    for _ in 0..*n {
+        let c = a + b;
+        a = b;
+        b = c;
+    }
+    a
+}
+
+fn inputs(len: usize) -> VecDeque<usize> {
+    let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+    (0..len)
+        .map(|_| rng.random_range(0..FIB_UPPER_BOUND) as usize)
+        .collect()
+}
+
+fn seq(inputs: VecDeque<usize>) -> Vec<Output> {
+    inputs.into_iter().map(map).filter(filter).collect()
+}
+
+fn rayon(inputs: VecDeque<usize>) -> Vec<Output> {
+    use rayon::iter::ParallelIterator;
+    inputs.into_par_iter().map(map).filter(filter).collect()
+}
+
+fn orx_into_vec(inputs: VecDeque<usize>) -> Vec<Output> {
+    inputs.into_par().map(map).filter(filter).collect()
+}
+
+fn orx_into_split_vec(inputs: VecDeque<usize>) -> SplitVec<Output> {
+    inputs.into_par().map(map).filter(filter).collect()
+}
+
+fn run(c: &mut Criterion) {
+    let treatments = [65_536, 65_536 * 4];
+
+    let mut group = c.benchmark_group("VecDeque-owned: collect_map_filter");
+
+    for n in &treatments {
+        let input = inputs(*n);
+        let input = || input.clone();
+        let expected = seq(input());
+        let mut sorted = seq(input());
+        sorted.sort();
+
+        group.bench_with_input(BenchmarkId::new("seq-into-vec", n), n, |b, _| {
+            assert_eq!(&expected, &seq(input()));
+            b.iter(|| seq(black_box(input())))
+        });
+
+        group.bench_with_input(BenchmarkId::new("rayon-into-vec", n), n, |b, _| {
+            assert_eq!(&expected, &rayon(input()));
+            b.iter(|| rayon(black_box(input())))
+        });
+
+        group.bench_with_input(BenchmarkId::new("orx-into-vec", n), n, |b, _| {
+            assert_eq!(&expected, &orx_into_vec(input()));
+            b.iter(|| orx_into_vec(black_box(input())))
+        });
+
+        group.bench_with_input(BenchmarkId::new("orx-into-split-vec", n), n, |b, _| {
+            assert_eq!(&expected, &orx_into_split_vec(input()));
+            b.iter(|| orx_into_split_vec(black_box(input())))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, run);
+criterion_main!(benches);

--- a/src/parallelizable_collection.rs
+++ b/src/parallelizable_collection.rs
@@ -13,7 +13,7 @@ use orx_concurrent_iter::{ConcurrentCollection, ConcurrentIterable};
 ///
 /// Note that every [`ConcurrentCollection`] type automatically implements [`ParallelizableCollection`].
 ///
-/// [`con_iter`]: crate::ConcurrentCollection::con_iter
+/// [`con_iter`]: orx_concurrent_iter::ConcurrentCollection::con_iter
 /// [`Collection`]: orx_iterable::Collection
 /// [`ConcurrentCollection`]: orx_concurrent_iter::ConcurrentCollection
 /// [`par`]: crate::ParallelizableCollection::par
@@ -49,9 +49,9 @@ pub trait ParallelizableCollection: ConcurrentCollection {
     ///
     /// Note that every [`ConcurrentCollection`] type automatically implements [`ParallelizableCollection`].
     ///
-    /// [`con_iter`]: crate::ConcurrentCollection::con_iter
+    /// [`con_iter`]: orx_concurrent_iter::ConcurrentCollection::con_iter
     /// [`Collection`]: orx_iterable::Collection
-    /// [`ConcurrentIter`]: crate::ConcurrentIter
+    /// [`ConcurrentIter`]: orx_concurrent_iter::ConcurrentIter
     /// [`par`]: crate::ParallelizableCollection::par
     /// [`into_par`]: crate::IntoParIter::into_par
     /// [`ParIter`]: crate::ParIter


### PR DESCRIPTION
Upgrade the concurrent iterator dependency which will enable parallelization of the following additional collections:
* `alloc::collections::VecDeque`
* `orx_split_vec::SplitVec`
* `orx_fixed_vec::FixedVec`
