### PR TITLE
Relaxing send trait bound

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-parallel"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 readme = "README.md"
@@ -13,14 +13,14 @@ categories = ["concurrency", "algorithms"]
 [dependencies]
 orx-pseudo-default = { version = "2.1.0", default-features = false }
 orx-pinned-vec = { version = "3.16.0", default-features = false }
-orx-fixed-vec = { version = "3.17.0", default-features = false }
-orx-split-vec = { version = "3.17.0", default-features = false }
-orx-pinned-concurrent-col = "2.13.0"
-orx-concurrent-bag = "2.12.0"
-orx-concurrent-ordered-bag = "2.12.0"
+orx-fixed-vec = { git = "https://github.com/orxfun/orx-fixed-vec", branch = "new-concurrent-iter-version", default-features = false }
+orx-split-vec = { git = "https://github.com/orxfun/orx-split-vec", branch = "new-concurrent-iter-version", default-features = false }
+orx-pinned-concurrent-col = { git = "https://github.com/orxfun/orx-pinned-concurrent-col", branch = "new-pinned-vector-versions", default-features = false }
+orx-concurrent-bag = { git = "https://github.com/orxfun/orx-concurrent-bag", branch = "new-pinned-vector-versions", default-features = false }
+orx-concurrent-ordered-bag = { git = "https://github.com/orxfun/orx-concurrent-ordered-bag", branch = "new-pinned-vector-versions", default-features = false }
 orx-iterable = { version = "1.3.0", default-features = false }
 orx-priority-queue = { version = "1.7.0", default-features = false }
-orx-concurrent-iter = { version = "2.2.0", default-features = false }
+orx-concurrent-iter = { git = "https://github.com/orxfun/orx-concurrent-iter", branch = "relaxing-send-trait-bound", default-features = false }
 rayon = { version = "1.10.0", optional = true }
 
 [dev-dependencies]

--- a/tests/trait_bounds.rs
+++ b/tests/trait_bounds.rs
@@ -1,0 +1,53 @@
+use orx_fixed_vec::FixedVec;
+use orx_split_vec::SplitVec;
+use std::collections::VecDeque;
+
+#[test]
+fn trait_bounds_parallelizable() {
+    use orx_parallel::Parallelizable;
+    fn fun(source: impl Parallelizable) {
+        let _iter = source.par();
+    }
+
+    fun(vec![1, 2, 3].as_slice());
+    fun(&vec![1, 2, 3]);
+    fun(&VecDeque::<String>::new());
+    fun(0..9);
+    fun(&FixedVec::<usize>::new(3));
+    fun(&SplitVec::<usize>::new());
+}
+
+#[test]
+fn trait_bounds_parallelizable_collection() {
+    use orx_parallel::ParallelizableCollection;
+    fn fun(source: impl ParallelizableCollection) {
+        let _iter = source.par();
+    }
+
+    fun(vec![1, 2, 3]);
+    fun(VecDeque::<String>::new());
+    fun(FixedVec::<usize>::new(3));
+    fun(SplitVec::<usize>::new());
+}
+
+#[test]
+fn trait_bounds_into_par_iter() {
+    use orx_parallel::IntoParIter;
+    fn fun(source: impl IntoParIter) {
+        let _iter = source.into_par();
+    }
+
+    // owned
+    fun(vec![1, 2, 3]);
+    fun(VecDeque::<String>::new());
+    fun(FixedVec::<usize>::new(3));
+    fun(SplitVec::<usize>::new());
+
+    // ref
+    fun(vec![1, 2, 3].as_slice());
+    fun(&vec![1, 2, 3]);
+    fun(&VecDeque::<String>::new());
+    fun(0..9);
+    fun(&FixedVec::<usize>::new(3));
+    fun(&SplitVec::<usize>::new());
+}


### PR DESCRIPTION
Relaxes `Send` requirements on `T` from concurrent and parallel iterators which yield elements of type `&T`. Notice that `&T` auto implements `Send` provided that `T` implements `Sync`. Therefore, `T: Send` requirement is unnecessary and irrelevant.

This version brings in fixes in the downstream libraries which together fixes the problem in parallelization.

As an example case of the fix, the following function did not compile in the prior version due to `Send` requirement. It requires in this version, as it should.

```rust
fn fun<T: Sync>(slice: &[T]) {
    let _iter = slice.par();
}
```

The problem is first reported here #58

Fixes #59
