### PR TITLE
avoid lag in fixed chunk runner

### DIFF
--- a/src/runner/fixed_chunk_runner/parallel_runner.rs
+++ b/src/runner/fixed_chunk_runner/parallel_runner.rs
@@ -1,11 +1,10 @@
-use crate::{
-    parameters::Params,
-    runner::{computation_kind::ComputationKind, parallel_runner::ParallelRunner},
-};
-
 use super::{
     chunk_size::ResolvedChunkSize, num_threads::maximum_num_threads,
     thread_runner::FixedChunkThreadRunner,
+};
+use crate::{
+    parameters::Params,
+    runner::{computation_kind::ComputationKind, parallel_runner::ParallelRunner},
 };
 use orx_concurrent_iter::ConcurrentIter;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -98,7 +97,6 @@ impl ParallelRunner for FixedChunkRunner {
         I: ConcurrentIter,
     {
         if num_spawned % LAG_PERIODICITY == 0 {
-            lag();
             match self.next_chunk(num_spawned, iter.try_get_len()) {
                 Some(c) => self.current_chunk_size.store(c, Ordering::Relaxed),
                 None => return false,
@@ -113,18 +111,4 @@ impl ParallelRunner for FixedChunkRunner {
             chunk_size: self.current_chunk_size.load(Ordering::Relaxed),
         }
     }
-}
-
-fn lag() {
-    fn fibonacci(n: i32) -> i32 {
-        let mut a = 0;
-        let mut b = 1;
-        for _ in 0..n {
-            let c = i32::saturating_add(a, b);
-            a = b;
-            b = c;
-        }
-        a
-    }
-    assert!(std::hint::black_box(fibonacci(1 << 16)) > 0);
 }


### PR DESCRIPTION
Avoids lags in fixed chunk parallel runner.

Benchmarks do not show any worsening in results.

Fixes #61 