### PR TITLE
New pools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,14 +53,15 @@ harness = false
 all-features = true
 
 [features]
-default = [
-    "std",
-    "pond",
-    "poolite",
-    "rayon-core",
-    "scoped-pool",
-    "scoped_threadpool",
-    "yastl",
-]
+default = ["std"]
+# default = [
+#     "std",
+#     "pond",
+#     "poolite",
+#     "rayon-core",
+#     "scoped-pool",
+#     "scoped_threadpool",
+#     "yastl",
+# ]
 std = []
 generic_iterator = ["rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rayon = { version = "1.11.0", optional = true }
 scoped_threadpool = { version = "0.1.9", optional = true }
 scoped-pool = { version = "1.0.0", optional = true }
 poolite = { version = "0.7.1", optional = true }
+yastl = { version = "0.1.2", optional = true }
 
 [dev-dependencies]
 chrono = "0.4.42"
@@ -47,6 +48,6 @@ harness = false
 all-features = true
 
 [features]
-default = ["std", "poolite"]
+default = ["std", "yastl"]
 std = []
 generic_iterator = ["rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ orx-self-or = { version = "1.2.0" }
 # optional thread pool dependencies
 rayon = { version = "1.11.0", optional = true }
 scoped_threadpool = { version = "0.1.9", optional = true }
+scoped-pool = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
 chrono = "0.4.42"
@@ -45,6 +46,6 @@ harness = false
 all-features = true
 
 [features]
-default = ["std"]
+default = ["std", "scoped-pool"]
 std = []
 generic_iterator = ["rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,14 @@ harness = false
 all-features = true
 
 [features]
-default = ["std", "rayon-core"]
+default = [
+    "std",
+    "pond",
+    "poolite",
+    "rayon-core",
+    "scoped-pool",
+    "scoped_threadpool",
+    "yastl",
+]
 std = []
 generic_iterator = ["rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ orx-self-or = { version = "1.2.0" }
 rayon = { version = "1.11.0", optional = true }
 scoped_threadpool = { version = "0.1.9", optional = true }
 scoped-pool = { version = "1.0.0", optional = true }
+poolite = { version = "0.7.1", optional = true }
 
 [dev-dependencies]
 chrono = "0.4.42"
@@ -46,6 +47,6 @@ harness = false
 all-features = true
 
 [features]
-default = ["std", "scoped-pool"]
+default = ["std", "poolite"]
 std = []
 generic_iterator = ["rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,17 @@ orx-pinned-concurrent-col = { version = "2.15.0", default-features = false }
 orx-priority-queue = { version = "1.7.0", default-features = false }
 orx-pseudo-default = { version = "2.1.0", default-features = false }
 orx-self-or = { version = "1.2.0" }
-# optional thread pool dependencies
+
+# optional: generic iterator
 rayon = { version = "1.11.0", optional = true }
-scoped_threadpool = { version = "0.1.9", optional = true }
-scoped-pool = { version = "1.0.0", optional = true }
-poolite = { version = "0.7.1", optional = true }
-yastl = { version = "0.1.2", optional = true }
+
+# optional: thread pool
 pond = { version = "0.3.1", optional = true }
+poolite = { version = "0.7.1", optional = true }
+rayon-core = { version = "1.13.0", optional = true }
+scoped-pool = { version = "1.0.0", optional = true }
+scoped_threadpool = { version = "0.1.9", optional = true }
+yastl = { version = "0.1.2", optional = true }
 
 [dev-dependencies]
 chrono = "0.4.42"
@@ -49,6 +53,6 @@ harness = false
 all-features = true
 
 [features]
-default = ["std", "pond"]
+default = ["std", "rayon-core"]
 std = []
 generic_iterator = ["rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ scoped_threadpool = { version = "0.1.9", optional = true }
 scoped-pool = { version = "1.0.0", optional = true }
 poolite = { version = "0.7.1", optional = true }
 yastl = { version = "0.1.2", optional = true }
+pond = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
 chrono = "0.4.42"
@@ -48,6 +49,6 @@ harness = false
 all-features = true
 
 [features]
-default = ["std", "yastl"]
+default = ["std", "pond"]
 std = []
 generic_iterator = ["rayon"]

--- a/examples/benchmark_pools.rs
+++ b/examples/benchmark_pools.rs
@@ -1,6 +1,4 @@
-mod utils;
-
-// cargo run --all-features --release --example using_pools
+// cargo run --all-features --release --example benchmark_pools
 // to run with all options:
 //
 // output:
@@ -15,7 +13,7 @@ mod utils;
 // ScopedThreadPool => 17.228307255s
 // Yastl => 43.914882593s
 
-// cargo run --all-features --release --example using_pools -- --pool-type scoped-pool
+// cargo run --all-features --release --example benchmark_pools -- --pool-type scoped-pool
 // to run only using scoped-pool
 //
 // output:
@@ -23,13 +21,15 @@ mod utils;
 // Args { pool_type: ScopedPool, num_threads: 16, len: 100000, num_repetitions: 1000 }
 // ScopedPool => 16.640308686s
 
-// cargo run --all-features --release --example using_pools -- --pool-type rayon-core --len 1000 --num-repetitions 10000
+// cargo run --all-features --release --example benchmark_pools -- --pool-type rayon-core --len 1000 --num-repetitions 10000
 // to run only using rayon-core ThreadPool, with 10000 repetitions for input size of 1000
 //
 // output:
 //
 // Args { pool_type: RayonCore, num_threads: 16, len: 1000, num_repetitions: 10000 }
 // RayonCore => 6.950370104s
+
+mod utils;
 
 fn main() {
     #[cfg(feature = "std")]
@@ -181,7 +181,7 @@ fn main() {
 
         fn run_pond(num_threads: usize, num_repetitions: usize, input: &[usize]) -> Vec<String> {
             let mut pool = PondPool::new_threads_unbounded(num_threads);
-            let mut runner = RunnerWithPondPool::from(&mut pool);
+            let mut runner = RunnerWithPool::from(&mut pool);
             run_with_runner(&mut runner, num_threads, num_repetitions, input)
         }
 
@@ -190,7 +190,7 @@ fn main() {
                 poolite::Builder::new().min(num_threads).max(num_threads),
             )
             .unwrap();
-            let mut runner = RunnerWithPoolitePool::from(&pool);
+            let mut runner = RunnerWithPool::from(&pool);
             run_with_runner(&mut runner, num_threads, num_repetitions, input)
         }
 
@@ -203,7 +203,7 @@ fn main() {
                 .num_threads(num_threads)
                 .build()
                 .unwrap();
-            let mut runner = RunnerWithRayonPool::from(&pool);
+            let mut runner = RunnerWithPool::from(&pool);
             run_with_runner(&mut runner, num_threads, num_repetitions, input)
         }
 
@@ -213,7 +213,7 @@ fn main() {
             input: &[usize],
         ) -> Vec<String> {
             let pool = scoped_pool::Pool::new(num_threads);
-            let mut runner = RunnerWithScopedPool::from(&pool);
+            let mut runner = RunnerWithPool::from(&pool);
             run_with_runner(&mut runner, num_threads, num_repetitions, input)
         }
 
@@ -223,13 +223,13 @@ fn main() {
             input: &[usize],
         ) -> Vec<String> {
             let mut pool = scoped_threadpool::Pool::new(num_threads as u32);
-            let mut runner = RunnerWithScopedThreadPool::from(&mut pool);
+            let mut runner = RunnerWithPool::from(&mut pool);
             run_with_runner(&mut runner, num_threads, num_repetitions, input)
         }
 
         fn run_yastl(num_threads: usize, num_repetitions: usize, input: &[usize]) -> Vec<String> {
             let pool = YastlPool::new(num_threads);
-            let mut runner = RunnerWithYastlPool::from(&pool);
+            let mut runner = RunnerWithPool::from(&pool);
             run_with_runner(&mut runner, num_threads, num_repetitions, input)
         }
 

--- a/examples/benchmark_pools.rs
+++ b/examples/benchmark_pools.rs
@@ -175,7 +175,7 @@ fn main() {
             num_repetitions: usize,
             input: &[usize],
         ) -> Vec<String> {
-            let mut runner = SequentialRunner::default();
+            let mut runner = RunnerWithPool::from(SequentialPool);
             run_with_runner(&mut runner, num_threads, num_repetitions, input)
         }
 

--- a/examples/using_pools.rs
+++ b/examples/using_pools.rs
@@ -1,0 +1,231 @@
+mod utils;
+
+// cargo run --all-features --release --example using_pools
+// to run with all options
+
+// cargo run --all-features --release --example using_pools -- --pool-type scoped-pool
+// to run only using scoped-pool
+
+// cargo run --all-features --release --example using_pools -- --pool-type scoped-thread-pool --len 100 --num-repetitions 100000
+// to run only using scoped_threadpool, with 100000 repetitions for input size of 100
+
+// cargo run --all-features --release --example using_pools -- --pool-type sequential
+// 11.02s
+
+// cargo run --all-features --release --example using_pools -- --pool-type std
+// 3.66s
+
+// cargo run --all-features --release --example using_pools -- --pool-type pond
+// 11.49s
+
+// cargo run --all-features --release --example using_pools -- --pool-type poolite
+// 12.27s
+
+// cargo run --all-features --release --example using_pools -- --pool-type rayon-core
+// 3.76s
+
+// cargo run --all-features --release --example using_pools -- --pool-type scoped_threadpool
+// 3.70s
+
+// cargo run --all-features --release --example using_pools -- --pool-type yastl
+// 11.47s
+
+fn main() {
+    #[cfg(feature = "std")]
+    #[cfg(feature = "pond")]
+    #[cfg(feature = "poolite")]
+    #[cfg(feature = "rayon-core")]
+    #[cfg(feature = "scoped-pool")]
+    #[cfg(feature = "scoped_threadpool")]
+    #[cfg(feature = "yastl")]
+    {
+        use clap::Parser;
+        use orx_parallel::runner::ParallelRunner;
+        use orx_parallel::*;
+        use std::hint::black_box;
+        use std::num::NonZeroUsize;
+        use std::time::SystemTime;
+
+        #[derive(Parser, Debug)]
+        struct Args {
+            /// Type of the thread pool to be used for computations.
+            #[arg(long, default_value_t, value_enum)]
+            pool_type: PoolType,
+            /// Number of threads.
+            #[arg(long, default_value_t = NonZeroUsize::new(16).unwrap())]
+            num_threads: NonZeroUsize,
+            /// Number of items in the input iterator.
+            #[arg(long, default_value_t = 100000)]
+            len: usize,
+            /// Number of repetitions to measure time; total time will be reported.
+            #[arg(long, default_value_t = 1000)]
+            num_repetitions: usize,
+        }
+
+        #[derive(clap::ValueEnum, Clone, Copy, Default, Debug)]
+        enum PoolType {
+            Std,
+            Sequential,
+            Pond,
+            Poolite,
+            RayonCore,
+            ScopedPool,
+            ScopedThreadPool,
+            Yastl,
+            #[default]
+            All,
+        }
+
+        impl PoolType {
+            fn run_single(self, nt: usize, reps: usize, input: &[usize], expected: &[String]) {
+                let now = SystemTime::now();
+                let result = match self {
+                    Self::Std => run_std(nt, reps, input),
+                    Self::Sequential => run_sequential(nt, reps, input),
+                    Self::Pond => run_pond(nt, reps, input),
+                    Self::Poolite => run_poolite(nt, reps, input),
+                    Self::RayonCore => run_rayon_core(nt, reps, input),
+                    Self::ScopedPool => run_scoped_pool(nt, reps, input),
+                    Self::ScopedThreadPool => run_scoped_threadpool(nt, reps, input),
+                    Self::Yastl => run_yastl(nt, reps, input),
+                    Self::All => panic!("all is handled by run_all"),
+                };
+                let elapsed = now.elapsed().unwrap();
+                println!("\n{self:?} => {elapsed:?}");
+                assert_eq!(expected, result);
+            }
+
+            fn run_all(nt: usize, reps: usize, input: &[usize], expected: &[String]) {
+                Self::Std.run_single(nt, reps, input, expected);
+                Self::Sequential.run_single(nt, reps, input, expected);
+                Self::Pond.run_single(nt, reps, input, expected);
+                Self::Poolite.run_single(nt, reps, input, expected);
+                Self::RayonCore.run_single(nt, reps, input, expected);
+                Self::ScopedPool.run_single(nt, reps, input, expected);
+                Self::ScopedThreadPool.run_single(nt, reps, input, expected);
+                Self::Yastl.run_single(nt, reps, input, expected);
+            }
+
+            fn run(self, nt: usize, reps: usize, input: &[usize], expected: &[String]) {
+                match self {
+                    Self::All => Self::run_all(nt, reps, input, expected),
+                    _ => self.run_single(nt, reps, input, expected),
+                }
+            }
+        }
+
+        fn run_with_runner<R: ParallelRunner>(
+            mut runner: R,
+            num_threads: usize,
+            num_repetitions: usize,
+            input: &[usize],
+        ) -> Vec<String> {
+            let mut result = vec![];
+            for _ in 0..num_repetitions {
+                result = black_box(
+                    input
+                        .par()
+                        .num_threads(num_threads)
+                        .with_runner(&mut runner)
+                        .map(|x| x.to_string())
+                        .filter_map(|x| (!x.starts_with('1')).then_some(x))
+                        .flat_map(|x| [format!("{}!", &x), x])
+                        .filter(|x| !x.starts_with('2'))
+                        .filter_map(|x| x.parse::<u64>().ok())
+                        .map(|x| x.to_string())
+                        .collect(),
+                );
+            }
+            result
+        }
+
+        fn run_std(num_threads: usize, num_repetitions: usize, input: &[usize]) -> Vec<String> {
+            let mut runner = DefaultRunner::default(); // StdRunner
+            run_with_runner(&mut runner, num_threads, num_repetitions, input)
+        }
+
+        fn run_sequential(
+            num_threads: usize,
+            num_repetitions: usize,
+            input: &[usize],
+        ) -> Vec<String> {
+            let mut runner = SequentialRunner::default();
+            run_with_runner(&mut runner, num_threads, num_repetitions, input)
+        }
+
+        fn run_pond(num_threads: usize, num_repetitions: usize, input: &[usize]) -> Vec<String> {
+            let mut pond = PondPool::new_threads_unbounded(num_threads);
+            let mut runner = RunnerWithPondPool::from(&mut pond);
+            run_with_runner(&mut runner, num_threads, num_repetitions, input)
+        }
+
+        fn run_poolite(num_threads: usize, num_repetitions: usize, input: &[usize]) -> Vec<String> {
+            let pond = poolite::Pool::with_builder(
+                poolite::Builder::new().min(num_threads).max(num_threads),
+            )
+            .unwrap();
+            let mut runner = RunnerWithPoolitePool::from(&pond);
+            run_with_runner(&mut runner, num_threads, num_repetitions, input)
+        }
+
+        fn run_rayon_core(
+            num_threads: usize,
+            num_repetitions: usize,
+            input: &[usize],
+        ) -> Vec<String> {
+            let pond = rayon_core::ThreadPoolBuilder::new()
+                .num_threads(num_threads)
+                .build()
+                .unwrap();
+            let mut runner = RunnerWithRayonPool::from(&pond);
+            run_with_runner(&mut runner, num_threads, num_repetitions, input)
+        }
+
+        fn run_scoped_pool(
+            num_threads: usize,
+            num_repetitions: usize,
+            input: &[usize],
+        ) -> Vec<String> {
+            let pond = scoped_pool::Pool::new(num_threads);
+            let mut runner = RunnerWithScopedPool::from(&pond);
+            run_with_runner(&mut runner, num_threads, num_repetitions, input)
+        }
+
+        fn run_scoped_threadpool(
+            num_threads: usize,
+            num_repetitions: usize,
+            input: &[usize],
+        ) -> Vec<String> {
+            let mut pond = scoped_threadpool::Pool::new(num_threads as u32);
+            let mut runner = RunnerWithScopedThreadPool::from(&mut pond);
+            run_with_runner(&mut runner, num_threads, num_repetitions, input)
+        }
+
+        fn run_yastl(num_threads: usize, num_repetitions: usize, input: &[usize]) -> Vec<String> {
+            let pond = YastlPool::new(num_threads);
+            let mut runner = RunnerWithYastlPool::from(&pond);
+            run_with_runner(&mut runner, num_threads, num_repetitions, input)
+        }
+
+        let args = Args::parse();
+        println!("\n{args:?}");
+
+        let input: Vec<_> = (0..args.len as usize).collect::<Vec<_>>();
+        let expected: Vec<_> = input
+            .iter()
+            .map(|x| x.to_string())
+            .filter_map(|x| (!x.starts_with('1')).then_some(x))
+            .flat_map(|x| [format!("{}!", &x), x])
+            .filter(|x| !x.starts_with('2'))
+            .filter_map(|x| x.parse::<u64>().ok())
+            .map(|x| x.to_string())
+            .collect();
+
+        args.pool_type.run(
+            args.num_threads.into(),
+            args.num_repetitions,
+            &input,
+            &expected,
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,3 +85,5 @@ pub use runner::RunnerWithScopedThreadPool;
 pub use runner::SequentialRunner;
 #[cfg(feature = "std")]
 pub use runner::StdRunner;
+#[cfg(feature = "yastl")]
+pub use runner::{RunnerWithYastlPool, YastlPool};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub use using::ParIterUsing;
 pub use runner::DefaultRunner;
 #[cfg(feature = "poolite")]
 pub use runner::RunnerWithPoolitePool;
-#[cfg(feature = "rayon")]
+#[cfg(feature = "rayon-core")]
 pub use runner::RunnerWithRayonPool;
 #[cfg(feature = "scoped-pool")]
 pub use runner::RunnerWithScopedPool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,8 @@ pub use special_type_sets::Sum;
 pub use using::ParIterUsing;
 
 pub use runner::DefaultRunner;
+#[cfg(feature = "poolite")]
+pub use runner::RunnerWithPoolitePool;
 #[cfg(feature = "rayon")]
 pub use runner::RunnerWithRayonPool;
 #[cfg(feature = "scoped-pool")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,10 +73,11 @@ pub use parameters::{ChunkSize, IterationOrder, NumThreads, Params};
 pub use special_type_sets::Sum;
 pub use using::ParIterUsing;
 
-pub use runner::{DefaultRunner, RunnerWithPool};
+pub use runner::{DefaultRunner, ParallelRunner, RunnerWithPool, SequentialPool};
 
 #[cfg(feature = "pond")]
 pub use runner::PondPool;
-pub use runner::SequentialPool;
+#[cfg(feature = "std")]
+pub use runner::StdDefaultPool;
 #[cfg(feature = "yastl")]
 pub use runner::YastlPool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,8 @@ pub use parameters::{ChunkSize, IterationOrder, NumThreads, Params};
 pub use special_type_sets::Sum;
 pub use using::ParIterUsing;
 
-pub use runner::DefaultRunner;
+pub use runner::{DefaultRunner, RunnerWithPool};
+
 #[cfg(feature = "poolite")]
 pub use runner::RunnerWithPoolitePool;
 #[cfg(feature = "rayon-core")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,5 +85,7 @@ pub use runner::RunnerWithScopedThreadPool;
 pub use runner::SequentialRunner;
 #[cfg(feature = "std")]
 pub use runner::StdRunner;
+#[cfg(feature = "pond")]
+pub use runner::{PondPool, RunnerWithPondPool};
 #[cfg(feature = "yastl")]
 pub use runner::{RunnerWithYastlPool, YastlPool};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,18 +75,8 @@ pub use using::ParIterUsing;
 
 pub use runner::{DefaultRunner, RunnerWithPool};
 
-#[cfg(feature = "poolite")]
-pub use runner::RunnerWithPoolitePool;
-#[cfg(feature = "rayon-core")]
-pub use runner::RunnerWithRayonPool;
-#[cfg(feature = "scoped-pool")]
-pub use runner::RunnerWithScopedPool;
-#[cfg(feature = "scoped_threadpool")]
-pub use runner::RunnerWithScopedThreadPool;
-pub use runner::SequentialRunner;
-#[cfg(feature = "std")]
-pub use runner::StdRunner;
 #[cfg(feature = "pond")]
-pub use runner::{PondPool, RunnerWithPondPool};
+pub use runner::PondPool;
+pub use runner::SequentialPool;
 #[cfg(feature = "yastl")]
-pub use runner::{RunnerWithYastlPool, YastlPool};
+pub use runner::YastlPool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@ pub use using::ParIterUsing;
 pub use runner::DefaultRunner;
 #[cfg(feature = "rayon")]
 pub use runner::RunnerWithRayonPool;
+#[cfg(feature = "scoped-pool")]
+pub use runner::RunnerWithScopedPool;
 #[cfg(feature = "scoped_threadpool")]
 pub use runner::RunnerWithScopedThreadPool;
 pub use runner::SequentialRunner;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ pub use parameters::{ChunkSize, IterationOrder, NumThreads, Params};
 pub use special_type_sets::Sum;
 pub use using::ParIterUsing;
 
-pub use runner::{DefaultRunner, ParallelRunner, RunnerWithPool, SequentialPool};
+pub use runner::{DefaultPool, DefaultRunner, ParallelRunner, RunnerWithPool, SequentialPool};
 
 #[cfg(feature = "pond")]
 pub use runner::PondPool;

--- a/src/par_iter.rs
+++ b/src/par_iter.rs
@@ -1,9 +1,9 @@
-use crate::ParIterResult;
 use crate::computational_variants::fallible_option::ParOption;
 use crate::par_iter_option::{IntoOption, ParIterOption};
 use crate::par_iter_result::IntoResult;
 use crate::runner::{DefaultRunner, ParallelRunner};
 use crate::using::{UsingClone, UsingFun};
+use crate::{ParIterResult, ParThreadPool, RunnerWithPool};
 use crate::{
     ParIterUsing, Params,
     collect_into::ParCollectInto,
@@ -249,6 +249,8 @@ where
 
     /// Rather than the [`DefaultRunner`], uses the parallel runner `Q` which implements [`ParallelRunner`].
     ///
+    /// See also [`with_pool`].
+    ///
     /// Parallel runner of each computation can be independently specified using `with_runner`.
     ///
     /// When not specified the default runner is used, which is:
@@ -261,9 +263,10 @@ where
     /// In this case, `RunnerWithPool` using a particular thread pool must be passed in using `with_runner`
     /// transformation to achieve parallel computation.
     ///
-    /// [`RunnerWithPool`]: crate::[`RunnerWithPool`]
-    /// [`StdDefaultPool`]: crate::[`StdDefaultPool`]
-    /// [`SequentialPool`]: crate::[`SequentialPool`]
+    /// [`RunnerWithPool`]: crate::RunnerWithPool
+    /// [`StdDefaultPool`]: crate::StdDefaultPool
+    /// [`SequentialPool`]: crate::SequentialPool
+    /// [`with_pool`]: crate::ParIter::with_pool
     ///
     /// # Examples
     ///
@@ -301,7 +304,73 @@ where
     ///     assert_eq!(sum, sum2);
     /// }
     /// ```
-    fn with_runner<Q: ParallelRunner>(self, orchestrator: Q) -> impl ParIter<Q, Item = Self::Item>;
+    fn with_runner<Q: ParallelRunner>(self, runner: Q) -> impl ParIter<Q, Item = Self::Item>;
+
+    /// Rather than [`DefaultPool`], uses the parallel runner with the given `pool` implementing
+    /// [`ParThreadPool`].
+    ///
+    /// See also [`with_runner`].
+    ///
+    /// Thread pool of each computation can be independently specified using `with_pool`.
+    ///
+    /// When not specified the default pool is used, which is:
+    /// * [`StdDefaultPool`] when "std" feature is enabled,
+    /// * [`SequentialPool`] when "std" feature is disabled.
+    ///
+    /// Note that [`StdDefaultPool`] uses standard native threads.
+    ///
+    /// When working in a no-std environment, the default pool falls back to sequential.
+    /// In this case, a thread pool must be passed in using `with_pool` transformation to achieve parallel computation.
+    ///
+    /// [`DefaultPool`]: crate::DefaultPool
+    /// [`RunnerWithPool`]: crate::RunnerWithPool
+    /// [`StdDefaultPool`]: crate::StdDefaultPool
+    /// [`SequentialPool`]: crate::SequentialPool
+    /// [`with_runner`]: crate::ParIter::with_runner
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_parallel::*;
+    ///
+    /// let inputs: Vec<_> = (0..42).collect();
+    ///
+    /// // uses the DefaultPool
+    /// // assuming "std" enabled, StdDefaultPool will be used; i.e., native threads
+    /// let sum = inputs.par().sum();
+    ///
+    /// // equivalent to:
+    /// let sum2 = inputs.par().with_pool(StdDefaultPool::default()).sum();
+    /// assert_eq!(sum, sum2);
+    ///
+    /// #[cfg(feature = "scoped_threadpool")]
+    /// {
+    ///     let mut pool = scoped_threadpool::Pool::new(8);
+    ///
+    ///     // uses the scoped_threadpool::Pool created with 8 threads
+    ///     let sum2 = inputs.par().with_pool(&mut pool).sum();
+    ///     assert_eq!(sum, sum2);
+    /// }
+    ///
+    /// #[cfg(feature = "rayon-core")]
+    /// {
+    ///     let pool = rayon_core::ThreadPoolBuilder::new()
+    ///         .num_threads(8)
+    ///         .build()
+    ///         .unwrap();
+    ///
+    ///     // uses the rayon-core::ThreadPool created with 8 threads
+    ///     let sum2 = inputs.par().with_pool(&pool).sum();
+    ///     assert_eq!(sum, sum2);
+    /// }
+    /// ```
+    fn with_pool<P: ParThreadPool>(
+        self,
+        pool: P,
+    ) -> impl ParIter<RunnerWithPool<P, R::Executor>, Item = Self::Item> {
+        let runner = RunnerWithPool::from(pool).with_executor::<R::Executor>();
+        self.with_runner(runner)
+    }
 
     // using transformations
 

--- a/src/par_iter.rs
+++ b/src/par_iter.rs
@@ -322,6 +322,11 @@ where
     /// When working in a no-std environment, the default pool falls back to sequential.
     /// In this case, a thread pool must be passed in using `with_pool` transformation to achieve parallel computation.
     ///
+    /// Note that if a thread pool, say `pool`, is of a type that implements [`ParThreadPool`]; then:
+    /// * `with_pool` can be called with owned value `with_pool(pool)` for all implementors; but also,
+    /// * with a shared reference `with_pool(&pool)` for most of the implementations (eg: rayon-core, yastl), and
+    /// * with a mutable reference `with_pool(&mut pool)` for others (eg: scoped_threadpool).
+    ///
     /// [`DefaultPool`]: crate::DefaultPool
     /// [`RunnerWithPool`]: crate::RunnerWithPool
     /// [`StdDefaultPool`]: crate::StdDefaultPool

--- a/src/par_iter_option.rs
+++ b/src/par_iter_option.rs
@@ -163,6 +163,7 @@ where
     /// See [`ParIter::with_runner`] for details.
     ///
     /// [`DefaultRunner`]: crate::DefaultRunner
+    /// [`ParIter::with_runner`]: crate::ParIter::with_runner
     fn with_runner<Q: ParallelRunner>(
         self,
         orchestrator: Q,
@@ -174,6 +175,7 @@ where
     /// See [`ParIter::with_pool`] for details.
     ///
     /// [`DefaultPool`]: crate::DefaultPool
+    /// [`ParIter::with_pool`]: crate::ParIter::with_pool
     fn with_pool<P: ParThreadPool>(
         self,
         pool: P,

--- a/src/par_iter_option.rs
+++ b/src/par_iter_option.rs
@@ -1,6 +1,8 @@
 use crate::default_fns::{map_count, reduce_sum, reduce_unit};
 use crate::runner::{DefaultRunner, ParallelRunner};
-use crate::{ChunkSize, IterationOrder, NumThreads, ParCollectInto, Sum};
+use crate::{
+    ChunkSize, IterationOrder, NumThreads, ParCollectInto, ParThreadPool, RunnerWithPool, Sum,
+};
 use core::cmp::Ordering;
 
 /// A parallel iterator for which the computation either completely succeeds,
@@ -158,11 +160,30 @@ where
 
     /// Rather than the [`DefaultRunner`], uses the parallel runner `Q` which implements [`ParallelRunner`].
     ///
-    /// See [`crate::ParIter::with_runner`] for details.
+    /// See [`ParIter::with_runner`] for details.
+    ///
+    /// [`DefaultRunner`]: crate::DefaultRunner
     fn with_runner<Q: ParallelRunner>(
         self,
         orchestrator: Q,
     ) -> impl ParIterOption<Q, Item = Self::Item>;
+
+    /// Rather than [`DefaultPool`], uses the parallel runner with the given `pool` implementing
+    /// [`ParThreadPool`].
+    ///
+    /// See [`ParIter::with_pool`] for details.
+    ///
+    /// [`DefaultPool`]: crate::DefaultPool
+    fn with_pool<P: ParThreadPool>(
+        self,
+        pool: P,
+    ) -> impl ParIterOption<RunnerWithPool<P, R::Executor>, Item = Self::Item>
+    where
+        Self: Sized,
+    {
+        let runner = RunnerWithPool::from(pool).with_executor::<R::Executor>();
+        self.with_runner(runner)
+    }
 
     // computation transformations
 

--- a/src/par_iter_result.rs
+++ b/src/par_iter_result.rs
@@ -200,6 +200,8 @@ where
     /// Rather than the [`DefaultRunner`], uses the parallel runner `Q` which implements [`ParallelRunner`].
     ///
     /// See [`ParIter::with_runner`] for details.
+    ///
+    /// [`DefaultRunner`]: crate::DefaultRunner
     fn with_runner<Q: ParallelRunner>(
         self,
         orchestrator: Q,
@@ -209,6 +211,8 @@ where
     /// [`ParThreadPool`].
     ///
     /// See [`ParIter::with_pool`] for details.
+    ///
+    /// [`DefaultPool`]: crate::DefaultPool
     fn with_pool<P: ParThreadPool>(
         self,
         pool: P,

--- a/src/par_iter_result.rs
+++ b/src/par_iter_result.rs
@@ -202,6 +202,7 @@ where
     /// See [`ParIter::with_runner`] for details.
     ///
     /// [`DefaultRunner`]: crate::DefaultRunner
+    /// [`ParIter::with_runner`]: crate::ParIter::with_runner
     fn with_runner<Q: ParallelRunner>(
         self,
         orchestrator: Q,
@@ -213,6 +214,7 @@ where
     /// See [`ParIter::with_pool`] for details.
     ///
     /// [`DefaultPool`]: crate::DefaultPool
+    /// [`ParIter::with_pool`]: crate::ParIter::with_pool
     fn with_pool<P: ParThreadPool>(
         self,
         pool: P,

--- a/src/par_iter_result.rs
+++ b/src/par_iter_result.rs
@@ -1,6 +1,6 @@
 use crate::default_fns::{map_count, reduce_sum, reduce_unit};
 use crate::runner::{DefaultRunner, ParallelRunner};
-use crate::{ChunkSize, IterationOrder, NumThreads, Sum};
+use crate::{ChunkSize, IterationOrder, NumThreads, ParThreadPool, RunnerWithPool, Sum};
 use crate::{ParCollectInto, ParIter, generic_values::fallible_iterators::ResultOfIter};
 use core::cmp::Ordering;
 
@@ -204,6 +204,21 @@ where
         self,
         orchestrator: Q,
     ) -> impl ParIterResult<Q, Item = Self::Item, Err = Self::Err>;
+
+    /// Rather than [`DefaultPool`], uses the parallel runner with the given `pool` implementing
+    /// [`ParThreadPool`].
+    ///
+    /// See [`ParIter::with_pool`] for details.
+    fn with_pool<P: ParThreadPool>(
+        self,
+        pool: P,
+    ) -> impl ParIterResult<RunnerWithPool<P, R::Executor>, Item = Self::Item, Err = Self::Err>
+    where
+        Self: Sized,
+    {
+        let runner = RunnerWithPool::from(pool).with_executor::<R::Executor>();
+        self.with_runner(runner)
+    }
 
     // computation transformations
 

--- a/src/par_thread_pool.rs
+++ b/src/par_thread_pool.rs
@@ -82,7 +82,7 @@ use orx_concurrent_bag::ConcurrentBag;
 ///
 ///     // or reuse a runner multiple times (identical under the hood)
 ///     let mut pool = scoped_threadpool::Pool::new(4);
-///     let runner = RunnerWithPool::from(&mut pool);
+///     let mut runner = RunnerWithPool::from(&mut pool);
 ///     let sum = (0..1000).par().with_runner(&mut runner).sum();
 ///     assert_eq!(sum, 1000 * 999 / 2);
 /// }

--- a/src/par_thread_pool.rs
+++ b/src/par_thread_pool.rs
@@ -40,7 +40,7 @@ use orx_concurrent_bag::ConcurrentBag;
 /// ```
 /// use orx_parallel::*;
 ///
-/// #[cfg(feature = "rayon")]
+/// #[cfg(feature = "rayon-core")]
 /// {
 ///     let pool = rayon::ThreadPoolBuilder::new()
 ///         .num_threads(4)
@@ -48,19 +48,19 @@ use orx_concurrent_bag::ConcurrentBag;
 ///         .unwrap();
 ///
 ///     // creating a runner for the computation
-///     let runner = RunnerWithRayonPool::from(&pool);
+///     let runner = RunnerWithPool::from(&pool);
 ///     let sum = (0..1000).par().with_runner(runner).sum();
 ///     assert_eq!(sum, 1000 * 999 / 2);
 ///
 ///     // or reuse a runner multiple times (identical under the hood)
-///     let mut runner = RunnerWithRayonPool::from(&pool);
+///     let mut runner = RunnerWithPool::from(&pool);
 ///     let sum = (0..1000).par().with_runner(&mut runner).sum();
 ///     assert_eq!(sum, 1000 * 999 / 2);
 /// }
 /// ```
 ///
 /// Note that since rayon::ThreadPool::scope only requires a shared reference `&self`,
-/// we can create as many runners as we want from the same thread pool and use them concurrently.
+/// we can concurrently create as many runners as we want from the same thread pool and use them concurrently.
 ///
 /// ## Scoped thread pool
 ///
@@ -76,13 +76,13 @@ use orx_concurrent_bag::ConcurrentBag;
 /// {
 ///     // creating a runner for the computation
 ///     let mut pool = scoped_threadpool::Pool::new(4);
-///     let runner = RunnerWithScopedThreadPool::from(&mut pool);
+///     let runner = RunnerWithPool::from(&mut pool);
 ///     let sum = (0..1000).par().with_runner(runner).sum();
 ///     assert_eq!(sum, 1000 * 999 / 2);
 ///
 ///     // or reuse a runner multiple times (identical under the hood)
 ///     let mut pool = scoped_threadpool::Pool::new(4);
-///     let mut runner = RunnerWithScopedThreadPool::from(&mut pool);
+///     let runner = RunnerWithPool::from(&mut pool);
 ///     let sum = (0..1000).par().with_runner(&mut runner).sum();
 ///     assert_eq!(sum, 1000 * 999 / 2);
 /// }

--- a/src/runner/implementations/mod.rs
+++ b/src/runner/implementations/mod.rs
@@ -9,6 +9,11 @@ mod std_runner;
 #[cfg(feature = "std")]
 pub use std_runner::StdRunner;
 
+#[cfg(feature = "pond")]
+mod pond;
+#[cfg(feature = "pond")]
+pub use pond::{PondPool, RunnerWithPondPool};
+
 #[cfg(feature = "poolite")]
 mod poolite;
 #[cfg(feature = "poolite")]

--- a/src/runner/implementations/mod.rs
+++ b/src/runner/implementations/mod.rs
@@ -18,3 +18,8 @@ pub use rayon::RunnerWithRayonPool;
 mod scoped_threadpool;
 #[cfg(feature = "scoped_threadpool")]
 pub use scoped_threadpool::RunnerWithScopedThreadPool;
+
+#[cfg(feature = "scoped-pool")]
+mod scoped_pool;
+#[cfg(feature = "scoped-pool")]
+pub use scoped_pool::RunnerWithScopedPool;

--- a/src/runner/implementations/mod.rs
+++ b/src/runner/implementations/mod.rs
@@ -19,10 +19,10 @@ mod poolite;
 #[cfg(feature = "poolite")]
 pub use poolite::RunnerWithPoolitePool;
 
-#[cfg(feature = "rayon")]
-mod rayon;
-#[cfg(feature = "rayon")]
-pub use rayon::RunnerWithRayonPool;
+#[cfg(feature = "rayon-core")]
+mod rayon_core;
+#[cfg(feature = "rayon-core")]
+pub use rayon_core::RunnerWithRayonPool;
 
 #[cfg(feature = "scoped-pool")]
 mod scoped_pool;

--- a/src/runner/implementations/mod.rs
+++ b/src/runner/implementations/mod.rs
@@ -28,3 +28,8 @@ pub use scoped_pool::RunnerWithScopedPool;
 mod scoped_threadpool;
 #[cfg(feature = "scoped_threadpool")]
 pub use scoped_threadpool::RunnerWithScopedThreadPool;
+
+#[cfg(feature = "yastl")]
+mod yastl;
+#[cfg(feature = "yastl")]
+pub use yastl::RunnerWithYastlPool;

--- a/src/runner/implementations/mod.rs
+++ b/src/runner/implementations/mod.rs
@@ -32,4 +32,4 @@ pub use scoped_threadpool::RunnerWithScopedThreadPool;
 #[cfg(feature = "yastl")]
 mod yastl;
 #[cfg(feature = "yastl")]
-pub use yastl::RunnerWithYastlPool;
+pub use yastl::{RunnerWithYastlPool, YastlPool};

--- a/src/runner/implementations/mod.rs
+++ b/src/runner/implementations/mod.rs
@@ -5,39 +5,31 @@ mod runner_with_pool;
 pub use runner_with_pool::RunnerWithPool;
 
 mod sequential;
-pub use sequential::SequentialRunner;
+pub use sequential::SequentialPool;
 
 #[cfg(feature = "std")]
 mod std_runner;
 #[cfg(feature = "std")]
-pub use std_runner::StdRunner;
+pub use std_runner::StdDefaultPool;
 
 #[cfg(feature = "pond")]
 mod pond;
 #[cfg(feature = "pond")]
-pub use pond::{PondPool, RunnerWithPondPool};
+pub use pond::PondPool;
 
 #[cfg(feature = "poolite")]
 mod poolite;
-#[cfg(feature = "poolite")]
-pub use poolite::RunnerWithPoolitePool;
 
 #[cfg(feature = "rayon-core")]
 mod rayon_core;
-#[cfg(feature = "rayon-core")]
-pub use rayon_core::RunnerWithRayonPool;
 
 #[cfg(feature = "scoped-pool")]
 mod scoped_pool;
-#[cfg(feature = "scoped-pool")]
-pub use scoped_pool::RunnerWithScopedPool;
 
 #[cfg(feature = "scoped_threadpool")]
 mod scoped_threadpool;
-#[cfg(feature = "scoped_threadpool")]
-pub use scoped_threadpool::RunnerWithScopedThreadPool;
 
 #[cfg(feature = "yastl")]
 mod yastl;
 #[cfg(feature = "yastl")]
-pub use yastl::{RunnerWithYastlPool, YastlPool};
+pub use yastl::YastlPool;

--- a/src/runner/implementations/mod.rs
+++ b/src/runner/implementations/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(test)]
 mod tests;
 
+mod runner_with_pool;
+pub use runner_with_pool::RunnerWithPool;
+
 mod sequential;
 pub use sequential::SequentialRunner;
 

--- a/src/runner/implementations/mod.rs
+++ b/src/runner/implementations/mod.rs
@@ -9,17 +9,22 @@ mod std_runner;
 #[cfg(feature = "std")]
 pub use std_runner::StdRunner;
 
+#[cfg(feature = "poolite")]
+mod poolite;
+#[cfg(feature = "poolite")]
+pub use poolite::RunnerWithPoolitePool;
+
 #[cfg(feature = "rayon")]
 mod rayon;
 #[cfg(feature = "rayon")]
 pub use rayon::RunnerWithRayonPool;
 
-#[cfg(feature = "scoped_threadpool")]
-mod scoped_threadpool;
-#[cfg(feature = "scoped_threadpool")]
-pub use scoped_threadpool::RunnerWithScopedThreadPool;
-
 #[cfg(feature = "scoped-pool")]
 mod scoped_pool;
 #[cfg(feature = "scoped-pool")]
 pub use scoped_pool::RunnerWithScopedPool;
+
+#[cfg(feature = "scoped_threadpool")]
+mod scoped_threadpool;
+#[cfg(feature = "scoped_threadpool")]
+pub use scoped_threadpool::RunnerWithScopedThreadPool;

--- a/src/runner/implementations/pond.rs
+++ b/src/runner/implementations/pond.rs
@@ -18,6 +18,7 @@ impl PondPool {
     pub fn new_threads_unbounded(num_threads: usize) -> Self {
         let num_threads = num_threads.min(1);
         let pool = Pool::new_threads_unbounded(num_threads);
+        #[allow(clippy::missing_panics_doc)]
         Self(pool, NonZeroUsize::new(num_threads).expect(">0"))
     }
 

--- a/src/runner/implementations/pond.rs
+++ b/src/runner/implementations/pond.rs
@@ -1,9 +1,6 @@
-use crate::{DefaultExecutor, ParThreadPool, ParallelExecutor, runner::ParallelRunner};
-use core::{marker::PhantomData, num::NonZeroUsize};
-use orx_self_or::SoM;
+use crate::par_thread_pool::ParThreadPool;
+use core::num::NonZeroUsize;
 use pond::{Pool, Scope};
-
-// POOL
 
 /// A wrapper for `pond::Pool` and number of threads it was built with.
 ///
@@ -95,53 +92,5 @@ impl ParThreadPool for &mut PondPool {
 
     fn max_num_threads(&self) -> NonZeroUsize {
         self.1
-    }
-}
-
-// RUNNER
-
-/// Parallel runner using threads provided by pond::Pool.
-pub struct RunnerWithPondPool<P, R = DefaultExecutor>
-where
-    R: ParallelExecutor,
-    P: SoM<PondPool> + ParThreadPool,
-{
-    pool: P,
-    runner: PhantomData<R>,
-}
-
-impl From<PondPool> for RunnerWithPondPool<PondPool, DefaultExecutor> {
-    fn from(pool: PondPool) -> Self {
-        Self {
-            pool,
-            runner: PhantomData,
-        }
-    }
-}
-
-impl<'a> From<&'a mut PondPool> for RunnerWithPondPool<&'a mut PondPool, DefaultExecutor> {
-    fn from(pool: &'a mut PondPool) -> Self {
-        Self {
-            pool,
-            runner: PhantomData,
-        }
-    }
-}
-
-impl<P, R> ParallelRunner for RunnerWithPondPool<P, R>
-where
-    R: ParallelExecutor,
-    P: SoM<PondPool> + ParThreadPool,
-{
-    type Executor = R;
-
-    type ThreadPool = P;
-
-    fn thread_pool(&self) -> &Self::ThreadPool {
-        &self.pool
-    }
-
-    fn thread_pool_mut(&mut self) -> &mut Self::ThreadPool {
-        &mut self.pool
     }
 }

--- a/src/runner/implementations/poolite.rs
+++ b/src/runner/implementations/poolite.rs
@@ -1,0 +1,112 @@
+use crate::{DefaultExecutor, ParThreadPool, ParallelExecutor, runner::ParallelRunner};
+use core::{marker::PhantomData, num::NonZeroUsize};
+use orx_self_or::SoR;
+use poolite::{Pool, Scoped};
+
+// POOL
+
+impl ParThreadPool for Pool {
+    type ScopeRef<'s, 'env, 'scope>
+        = &'s Scoped<'env, 'scope>
+    where
+        'scope: 's,
+        'env: 'scope + 's;
+
+    fn run_in_scope<'s, 'env, 'scope, W>(s: &Self::ScopeRef<'s, 'env, 'scope>, work: W)
+    where
+        'scope: 's,
+        'env: 'scope + 's,
+        W: Fn() + Send + 'scope + 'env,
+    {
+        s.push(work);
+    }
+
+    fn scoped_computation<'env, 'scope, F>(&'env mut self, f: F)
+    where
+        'env: 'scope,
+        for<'s> F: FnOnce(&'s Scoped<'env, 'scope>) + Send,
+    {
+        self.scoped(f);
+    }
+
+    fn max_num_threads(&self) -> NonZeroUsize {
+        NonZeroUsize::new(self.threads_future().max(1)).expect(">0")
+    }
+}
+
+impl ParThreadPool for &Pool {
+    type ScopeRef<'s, 'env, 'scope>
+        = &'s Scoped<'env, 'scope>
+    where
+        'scope: 's,
+        'env: 'scope + 's;
+
+    fn run_in_scope<'s, 'env, 'scope, W>(s: &Self::ScopeRef<'s, 'env, 'scope>, work: W)
+    where
+        'scope: 's,
+        'env: 'scope + 's,
+        W: Fn() + Send + 'scope + 'env,
+    {
+        s.push(work);
+    }
+
+    fn scoped_computation<'env, 'scope, F>(&'env mut self, f: F)
+    where
+        'env: 'scope,
+        for<'s> F: FnOnce(&'s Scoped<'env, 'scope>) + Send,
+    {
+        self.scoped(f);
+    }
+
+    fn max_num_threads(&self) -> NonZeroUsize {
+        NonZeroUsize::new(self.threads_future().max(1)).expect(">0")
+    }
+}
+
+// RUNNER
+
+/// Parallel runner using threads provided by poolite::Pool.
+pub struct RunnerWithPoolitePool<P, R = DefaultExecutor>
+where
+    R: ParallelExecutor,
+    P: SoR<Pool> + ParThreadPool,
+{
+    pool: P,
+    runner: PhantomData<R>,
+}
+
+impl From<Pool> for RunnerWithPoolitePool<Pool, DefaultExecutor> {
+    fn from(pool: Pool) -> Self {
+        Self {
+            pool,
+            runner: PhantomData,
+        }
+    }
+}
+
+impl<'a> From<&'a Pool> for RunnerWithPoolitePool<&'a Pool, DefaultExecutor> {
+    fn from(pool: &'a Pool) -> Self {
+        Self {
+            pool,
+            runner: PhantomData,
+        }
+    }
+}
+
+impl<P, R> ParallelRunner for RunnerWithPoolitePool<P, R>
+where
+    R: ParallelExecutor,
+    P: SoR<Pool> + ParThreadPool,
+{
+    type Executor = R;
+
+    type ThreadPool = P;
+
+    fn thread_pool(&self) -> &Self::ThreadPool {
+        &self.pool
+    }
+
+    fn thread_pool_mut(&mut self) -> &mut Self::ThreadPool {
+        &mut self.pool
+    }
+}

--- a/src/runner/implementations/poolite.rs
+++ b/src/runner/implementations/poolite.rs
@@ -1,9 +1,6 @@
-use crate::{DefaultExecutor, ParThreadPool, ParallelExecutor, runner::ParallelRunner};
-use core::{marker::PhantomData, num::NonZeroUsize};
-use orx_self_or::SoR;
+use crate::par_thread_pool::ParThreadPool;
+use core::num::NonZeroUsize;
 use poolite::{Pool, Scoped};
-
-// POOL
 
 impl ParThreadPool for Pool {
     type ScopeRef<'s, 'env, 'scope>
@@ -60,53 +57,5 @@ impl ParThreadPool for &Pool {
 
     fn max_num_threads(&self) -> NonZeroUsize {
         NonZeroUsize::new(self.threads_future().max(1)).expect(">0")
-    }
-}
-
-// RUNNER
-
-/// Parallel runner using threads provided by poolite::Pool.
-pub struct RunnerWithPoolitePool<P, R = DefaultExecutor>
-where
-    R: ParallelExecutor,
-    P: SoR<Pool> + ParThreadPool,
-{
-    pool: P,
-    runner: PhantomData<R>,
-}
-
-impl From<Pool> for RunnerWithPoolitePool<Pool, DefaultExecutor> {
-    fn from(pool: Pool) -> Self {
-        Self {
-            pool,
-            runner: PhantomData,
-        }
-    }
-}
-
-impl<'a> From<&'a Pool> for RunnerWithPoolitePool<&'a Pool, DefaultExecutor> {
-    fn from(pool: &'a Pool) -> Self {
-        Self {
-            pool,
-            runner: PhantomData,
-        }
-    }
-}
-
-impl<P, R> ParallelRunner for RunnerWithPoolitePool<P, R>
-where
-    R: ParallelExecutor,
-    P: SoR<Pool> + ParThreadPool,
-{
-    type Executor = R;
-
-    type ThreadPool = P;
-
-    fn thread_pool(&self) -> &Self::ThreadPool {
-        &self.pool
-    }
-
-    fn thread_pool_mut(&mut self) -> &mut Self::ThreadPool {
-        &mut self.pool
     }
 }

--- a/src/runner/implementations/rayon.rs
+++ b/src/runner/implementations/rayon.rs
@@ -67,7 +67,7 @@ impl ParThreadPool for &rayon::ThreadPool {
 
 // RUNNER
 
-/// Parallel runner using threads provided by rayon thread pool.
+/// Parallel runner using threads provided by rayon::ThreadPool.
 pub struct RunnerWithRayonPool<P, R = DefaultExecutor>
 where
     R: ParallelExecutor,

--- a/src/runner/implementations/rayon_core.rs
+++ b/src/runner/implementations/rayon_core.rs
@@ -1,11 +1,6 @@
-use crate::{
-    DefaultExecutor, ParallelExecutor, par_thread_pool::ParThreadPool, runner::ParallelRunner,
-};
-use core::{marker::PhantomData, num::NonZeroUsize};
-use orx_self_or::SoR;
+use crate::par_thread_pool::ParThreadPool;
+use core::num::NonZeroUsize;
 use rayon_core::ThreadPool;
-
-// POOL
 
 impl ParThreadPool for ThreadPool {
     type ScopeRef<'s, 'env, 'scope>
@@ -62,53 +57,5 @@ impl ParThreadPool for &rayon_core::ThreadPool {
 
     fn max_num_threads(&self) -> NonZeroUsize {
         NonZeroUsize::new(self.current_num_threads().max(1)).expect(">0")
-    }
-}
-
-// RUNNER
-
-/// Parallel runner using threads provided by rayon_core::ThreadPool.
-pub struct RunnerWithRayonPool<P, R = DefaultExecutor>
-where
-    R: ParallelExecutor,
-    P: SoR<ThreadPool> + ParThreadPool,
-{
-    pool: P,
-    runner: PhantomData<R>,
-}
-
-impl From<ThreadPool> for RunnerWithRayonPool<ThreadPool, DefaultExecutor> {
-    fn from(pool: ThreadPool) -> Self {
-        Self {
-            pool,
-            runner: PhantomData,
-        }
-    }
-}
-
-impl<'a> From<&'a ThreadPool> for RunnerWithRayonPool<&'a ThreadPool, DefaultExecutor> {
-    fn from(pool: &'a ThreadPool) -> Self {
-        Self {
-            pool,
-            runner: PhantomData,
-        }
-    }
-}
-
-impl<P, R> ParallelRunner for RunnerWithRayonPool<P, R>
-where
-    R: ParallelExecutor,
-    P: SoR<ThreadPool> + ParThreadPool,
-{
-    type Executor = R;
-
-    type ThreadPool = P;
-
-    fn thread_pool(&self) -> &Self::ThreadPool {
-        &self.pool
-    }
-
-    fn thread_pool_mut(&mut self) -> &mut Self::ThreadPool {
-        &mut self.pool
     }
 }

--- a/src/runner/implementations/rayon_core.rs
+++ b/src/runner/implementations/rayon_core.rs
@@ -3,13 +3,13 @@ use crate::{
 };
 use core::{marker::PhantomData, num::NonZeroUsize};
 use orx_self_or::SoR;
-use rayon::ThreadPool;
+use rayon_core::ThreadPool;
 
 // POOL
 
 impl ParThreadPool for ThreadPool {
     type ScopeRef<'s, 'env, 'scope>
-        = &'s rayon::Scope<'scope>
+        = &'s rayon_core::Scope<'scope>
     where
         'scope: 's,
         'env: 'scope + 's;
@@ -26,7 +26,7 @@ impl ParThreadPool for ThreadPool {
     fn scoped_computation<'env, 'scope, F>(&'env mut self, f: F)
     where
         'env: 'scope,
-        for<'s> F: FnOnce(&'s rayon::Scope<'scope>) + Send,
+        for<'s> F: FnOnce(&'s rayon_core::Scope<'scope>) + Send,
     {
         self.scope(f)
     }
@@ -36,9 +36,9 @@ impl ParThreadPool for ThreadPool {
     }
 }
 
-impl ParThreadPool for &rayon::ThreadPool {
+impl ParThreadPool for &rayon_core::ThreadPool {
     type ScopeRef<'s, 'env, 'scope>
-        = &'s rayon::Scope<'scope>
+        = &'s rayon_core::Scope<'scope>
     where
         'scope: 's,
         'env: 'scope + 's;
@@ -55,7 +55,7 @@ impl ParThreadPool for &rayon::ThreadPool {
     fn scoped_computation<'env, 'scope, F>(&'env mut self, f: F)
     where
         'env: 'scope,
-        for<'s> F: FnOnce(&'s rayon::Scope<'scope>) + Send,
+        for<'s> F: FnOnce(&'s rayon_core::Scope<'scope>) + Send,
     {
         self.scope(f)
     }
@@ -67,7 +67,7 @@ impl ParThreadPool for &rayon::ThreadPool {
 
 // RUNNER
 
-/// Parallel runner using threads provided by rayon::ThreadPool.
+/// Parallel runner using threads provided by rayon_core::ThreadPool.
 pub struct RunnerWithRayonPool<P, R = DefaultExecutor>
 where
     R: ParallelExecutor,

--- a/src/runner/implementations/runner_with_pool.rs
+++ b/src/runner/implementations/runner_with_pool.rs
@@ -10,6 +10,19 @@ where
     runner: PhantomData<R>,
 }
 
+impl<P, R> Default for RunnerWithPool<P, R>
+where
+    P: ParThreadPool + Default,
+    R: ParallelExecutor,
+{
+    fn default() -> Self {
+        Self {
+            pool: Default::default(),
+            runner: PhantomData,
+        }
+    }
+}
+
 impl<P: ParThreadPool> From<P> for RunnerWithPool<P, DefaultExecutor> {
     fn from(pool: P) -> Self {
         Self {

--- a/src/runner/implementations/runner_with_pool.rs
+++ b/src/runner/implementations/runner_with_pool.rs
@@ -1,0 +1,48 @@
+use crate::{DefaultExecutor, ParThreadPool, ParallelExecutor, runner::ParallelRunner};
+use core::marker::PhantomData;
+
+pub struct RunnerWithPool<P, R = DefaultExecutor>
+where
+    P: ParThreadPool,
+    R: ParallelExecutor,
+{
+    pool: P,
+    runner: PhantomData<R>,
+}
+
+impl<P: ParThreadPool> From<P> for RunnerWithPool<P, DefaultExecutor> {
+    fn from(pool: P) -> Self {
+        Self {
+            pool,
+            runner: PhantomData,
+        }
+    }
+}
+
+impl<P, R> RunnerWithPool<P, R>
+where
+    P: ParThreadPool,
+    R: ParallelExecutor,
+{
+    pub fn into_inner_pool(self) -> P {
+        self.pool
+    }
+}
+
+impl<P, R> ParallelRunner for RunnerWithPool<P, R>
+where
+    P: ParThreadPool,
+    R: ParallelExecutor,
+{
+    type Executor = R;
+
+    type ThreadPool = P;
+
+    fn thread_pool(&self) -> &Self::ThreadPool {
+        &self.pool
+    }
+
+    fn thread_pool_mut(&mut self) -> &mut Self::ThreadPool {
+        &mut self.pool
+    }
+}

--- a/src/runner/implementations/runner_with_pool.rs
+++ b/src/runner/implementations/runner_with_pool.rs
@@ -11,6 +11,8 @@ use core::marker::PhantomData;
 /// * `RunnerWithPool<StdDefaultPool>` when "std" feature is enabled,
 /// * `RunnerWithPool<SequentialPool>` when "std" feature is disabled.
 ///
+/// [`DefaultRunner`]: crate::DefaultRunner
+///
 /// # Examples
 ///
 /// ```

--- a/src/runner/implementations/runner_with_pool.rs
+++ b/src/runner/implementations/runner_with_pool.rs
@@ -173,6 +173,14 @@ where
     pub fn into_inner_pool(self) -> P {
         self.pool
     }
+
+    /// Converts the runner into one using the [`ParallelExecutor`] `Q` rather than `R`.
+    pub fn with_executor<Q: ParallelExecutor>(self) -> RunnerWithPool<P, Q> {
+        RunnerWithPool {
+            pool: self.pool,
+            runner: PhantomData,
+        }
+    }
 }
 
 impl<P, R> ParallelRunner for RunnerWithPool<P, R>

--- a/src/runner/implementations/runner_with_pool.rs
+++ b/src/runner/implementations/runner_with_pool.rs
@@ -124,6 +124,46 @@ where
     P: ParThreadPool,
     R: ParallelExecutor,
 {
+    /// Converts the runner into the wrapped underlying pool.
+    ///
+    /// Note that a `RunnerWithPool` can always be created from owned `pool`, but also from
+    /// * `&pool` in most cases,
+    /// * `&mut pool` in others.
+    ///
+    /// This function is only relevant when the runner is created from owned pool, in which case
+    /// `into_inner_pool` can be used to get back ownership of the pool.
+    ///
+    /// # Example
+    ///
+    /// The following example demonstrates the use case for rayon-core thread pool; however, it
+    /// holds for all thread pool implementations.
+    ///
+    /// ```
+    /// use orx_parallel::*;
+    ///
+    /// #[cfg(feature = "rayon-core")]
+    /// {
+    ///     let pool = rayon_core::ThreadPoolBuilder::new()
+    ///         .num_threads(8)
+    ///         .build()
+    ///         .unwrap();
+    ///
+    ///     // create runner owning the pool
+    ///     let mut runner = RunnerWithPool::from(pool);
+    ///
+    ///     // use runner, and hence the pool, in parallel computations
+    ///     let sum = input.par().with_runner(&mut runner).sum();
+    ///     let max = input.par().with_runner(&mut runner).max();
+    ///     let txt: Vec<_> = input
+    ///         .par()
+    ///         .with_runner(&mut runner)
+    ///         .map(|x| x.to_string())
+    ///         .collect();
+    ///
+    ///     // get back ownership of the pool
+    ///     let pool: rayon_core::ThreadPool = runner.into_inner_pool();
+    /// }
+    /// ```
     pub fn into_inner_pool(self) -> P {
         self.pool
     }
@@ -144,5 +184,102 @@ where
 
     fn thread_pool_mut(&mut self) -> &mut Self::ThreadPool {
         &mut self.pool
+    }
+}
+
+#[cfg(test)]
+mod tsts {
+    use crate::*;
+    use alloc::string::{String, ToString};
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn abc() {
+        // parallel computation generic over parallel runner; and hence, the thread pool
+        fn run_with_runner<R: ParallelRunner>(runner: R, input: &[usize]) -> Vec<String> {
+            input
+                .par()
+                .with_runner(runner)
+                .flat_map(|x| [*x, 2 * x, x / 7])
+                .map(|x| x.to_string())
+                .collect()
+        }
+
+        let vec: Vec<_> = (0..42).collect();
+        let input = vec.as_slice();
+
+        // runs on the main thread
+        let runner = RunnerWithPool::from(SequentialPool);
+        let expected = run_with_runner(runner, input);
+
+        // uses native threads
+        let runner = RunnerWithPool::from(StdDefaultPool::default());
+        let result = run_with_runner(runner, input);
+        assert_eq!(&expected, &result);
+
+        // uses rayon-core ThreadPool with 8 threads
+        #[cfg(feature = "rayon-core")]
+        {
+            let pool = rayon_core::ThreadPoolBuilder::new()
+                .num_threads(8)
+                .build()
+                .unwrap();
+
+            // create runner owning the pool
+            let mut runner = RunnerWithPool::from(pool);
+
+            // use runner, and hence the pool, in parallel computations
+            let sum = input.par().with_runner(&mut runner).sum();
+            let max = input.par().with_runner(&mut runner).max();
+            let txt: Vec<_> = input
+                .par()
+                .with_runner(&mut runner)
+                .map(|x| x.to_string())
+                .collect();
+
+            // get back ownership of the pool
+            let pool: rayon_core::ThreadPool = runner.into_inner_pool();
+        }
+
+        // uses scoped-pool Pool with 8 threads
+        #[cfg(feature = "scoped-pool")]
+        {
+            let pool = scoped_pool::Pool::new(8);
+            let result = run_with_runner(RunnerWithPool::from(&pool), input);
+            assert_eq!(&expected, &result);
+        }
+
+        // uses scoped_threadpool Pool with 8 threads
+        #[cfg(feature = "scoped_threadpool")]
+        {
+            let mut pool = scoped_threadpool::Pool::new(8);
+            let result = run_with_runner(RunnerWithPool::from(&mut pool), input); // requires &mut pool
+            assert_eq!(&expected, &result);
+        }
+
+        // uses yastl Pool wrapped as YastlPool with 8 threads
+        #[cfg(feature = "yastl")]
+        {
+            let pool = YastlPool::new(8);
+            let result = run_with_runner(RunnerWithPool::from(&pool), input);
+            assert_eq!(&expected, &result);
+        }
+
+        // uses pond Pool wrapped as PondPool with 8 threads
+        #[cfg(feature = "pond")]
+        {
+            let mut pool = PondPool::new_threads_unbounded(8);
+            let result = run_with_runner(RunnerWithPool::from(&mut pool), input); // requires &mut pool
+            assert_eq!(&expected, &result);
+        }
+
+        // uses poolite Pool with 8 threads
+        #[cfg(feature = "poolite")]
+        {
+            let pool = poolite::Pool::with_builder(poolite::Builder::new().min(8).max(8)).unwrap();
+            let result = run_with_runner(RunnerWithPool::from(&pool), input);
+            assert_eq!(&expected, &result);
+        }
     }
 }

--- a/src/runner/implementations/runner_with_pool.rs
+++ b/src/runner/implementations/runner_with_pool.rs
@@ -141,6 +141,9 @@ where
     /// ```
     /// use orx_parallel::*;
     ///
+    /// let vec: Vec<_> = (0..42).collect();
+    /// let input = vec.as_slice();
+    ///
     /// #[cfg(feature = "rayon-core")]
     /// {
     ///     let pool = rayon_core::ThreadPoolBuilder::new()

--- a/src/runner/implementations/runner_with_pool.rs
+++ b/src/runner/implementations/runner_with_pool.rs
@@ -3,8 +3,9 @@ use core::marker::PhantomData;
 
 /// Parallel runner with a given pool of type `P` and parallel executor of `R`.
 ///
-/// It can be constructed from any pool, or reference of a pool, implementing [`ParThreadPool`]
-/// since `RunnerWithPool<P, DefaultExecutor>` implements `From<P>`.
+/// A `RunnerWithPool` can always be created from owned `pool` implementing [`ParThreadPool`], but also from
+/// * `&pool` in most cases,
+/// * `&mut pool` in others.
 ///
 /// Note that default parallel runner; i.e., [`DefaultRunner`] is:
 /// * `RunnerWithPool<StdDefaultPool>` when "std" feature is enabled,
@@ -28,7 +29,7 @@ use core::marker::PhantomData;
 /// let vec: Vec<_> = (0..42).collect();
 /// let input = vec.as_slice();
 ///
-/// // runs on the main thread
+/// // runs sequentially on the main thread
 /// let runner = RunnerWithPool::from(SequentialPool);
 /// let expected = run_with_runner(runner, input);
 ///
@@ -187,102 +188,5 @@ where
 
     fn thread_pool_mut(&mut self) -> &mut Self::ThreadPool {
         &mut self.pool
-    }
-}
-
-#[cfg(test)]
-mod tsts {
-    use crate::*;
-    use alloc::string::{String, ToString};
-    use alloc::vec;
-    use alloc::vec::Vec;
-
-    #[test]
-    fn abc() {
-        // parallel computation generic over parallel runner; and hence, the thread pool
-        fn run_with_runner<R: ParallelRunner>(runner: R, input: &[usize]) -> Vec<String> {
-            input
-                .par()
-                .with_runner(runner)
-                .flat_map(|x| [*x, 2 * x, x / 7])
-                .map(|x| x.to_string())
-                .collect()
-        }
-
-        let vec: Vec<_> = (0..42).collect();
-        let input = vec.as_slice();
-
-        // runs on the main thread
-        let runner = RunnerWithPool::from(SequentialPool);
-        let expected = run_with_runner(runner, input);
-
-        // uses native threads
-        let runner = RunnerWithPool::from(StdDefaultPool::default());
-        let result = run_with_runner(runner, input);
-        assert_eq!(&expected, &result);
-
-        // uses rayon-core ThreadPool with 8 threads
-        #[cfg(feature = "rayon-core")]
-        {
-            let pool = rayon_core::ThreadPoolBuilder::new()
-                .num_threads(8)
-                .build()
-                .unwrap();
-
-            // create runner owning the pool
-            let mut runner = RunnerWithPool::from(pool);
-
-            // use runner, and hence the pool, in parallel computations
-            let sum = input.par().with_runner(&mut runner).sum();
-            let max = input.par().with_runner(&mut runner).max();
-            let txt: Vec<_> = input
-                .par()
-                .with_runner(&mut runner)
-                .map(|x| x.to_string())
-                .collect();
-
-            // get back ownership of the pool
-            let pool: rayon_core::ThreadPool = runner.into_inner_pool();
-        }
-
-        // uses scoped-pool Pool with 8 threads
-        #[cfg(feature = "scoped-pool")]
-        {
-            let pool = scoped_pool::Pool::new(8);
-            let result = run_with_runner(RunnerWithPool::from(&pool), input);
-            assert_eq!(&expected, &result);
-        }
-
-        // uses scoped_threadpool Pool with 8 threads
-        #[cfg(feature = "scoped_threadpool")]
-        {
-            let mut pool = scoped_threadpool::Pool::new(8);
-            let result = run_with_runner(RunnerWithPool::from(&mut pool), input); // requires &mut pool
-            assert_eq!(&expected, &result);
-        }
-
-        // uses yastl Pool wrapped as YastlPool with 8 threads
-        #[cfg(feature = "yastl")]
-        {
-            let pool = YastlPool::new(8);
-            let result = run_with_runner(RunnerWithPool::from(&pool), input);
-            assert_eq!(&expected, &result);
-        }
-
-        // uses pond Pool wrapped as PondPool with 8 threads
-        #[cfg(feature = "pond")]
-        {
-            let mut pool = PondPool::new_threads_unbounded(8);
-            let result = run_with_runner(RunnerWithPool::from(&mut pool), input); // requires &mut pool
-            assert_eq!(&expected, &result);
-        }
-
-        // uses poolite Pool with 8 threads
-        #[cfg(feature = "poolite")]
-        {
-            let pool = poolite::Pool::with_builder(poolite::Builder::new().min(8).max(8)).unwrap();
-            let result = run_with_runner(RunnerWithPool::from(&pool), input);
-            assert_eq!(&expected, &result);
-        }
     }
 }

--- a/src/runner/implementations/scoped_pool.rs
+++ b/src/runner/implementations/scoped_pool.rs
@@ -1,0 +1,111 @@
+use crate::{DefaultExecutor, ParThreadPool, ParallelExecutor, runner::ParallelRunner};
+use core::{marker::PhantomData, num::NonZeroUsize};
+use orx_self_or::SoR;
+use scoped_pool::{Pool, Scope};
+
+// POOL
+
+impl ParThreadPool for Pool {
+    type ScopeRef<'s, 'env, 'scope>
+        = &'s Scope<'scope>
+    where
+        'scope: 's,
+        'env: 'scope + 's;
+
+    fn run_in_scope<'s, 'env, 'scope, W>(s: &Self::ScopeRef<'s, 'env, 'scope>, work: W)
+    where
+        'scope: 's,
+        'env: 'scope + 's,
+        W: Fn() + Send + 'scope + 'env,
+    {
+        s.execute(work);
+    }
+
+    fn scoped_computation<'env, 'scope, F>(&'env mut self, f: F)
+    where
+        'env: 'scope,
+        for<'s> F: FnOnce(&Scope<'scope>) + Send,
+    {
+        self.scoped(f)
+    }
+
+    fn max_num_threads(&self) -> NonZeroUsize {
+        NonZeroUsize::new(self.workers().max(1)).expect(">0")
+    }
+}
+
+impl ParThreadPool for &Pool {
+    type ScopeRef<'s, 'env, 'scope>
+        = &'s Scope<'scope>
+    where
+        'scope: 's,
+        'env: 'scope + 's;
+
+    fn run_in_scope<'s, 'env, 'scope, W>(s: &Self::ScopeRef<'s, 'env, 'scope>, work: W)
+    where
+        'scope: 's,
+        'env: 'scope + 's,
+        W: Fn() + Send + 'scope + 'env,
+    {
+        s.execute(work);
+    }
+
+    fn scoped_computation<'env, 'scope, F>(&'env mut self, f: F)
+    where
+        'env: 'scope,
+        for<'s> F: FnOnce(&Scope<'scope>) + Send,
+    {
+        self.scoped(f)
+    }
+
+    fn max_num_threads(&self) -> core::num::NonZeroUsize {
+        NonZeroUsize::new(self.workers().max(1)).expect(">0")
+    }
+}
+
+// RUNNER
+
+pub struct RunnerWithScopedPool<P, R = DefaultExecutor>
+where
+    R: ParallelExecutor,
+    P: SoR<Pool> + ParThreadPool,
+{
+    pool: P,
+    runner: PhantomData<R>,
+}
+
+impl From<Pool> for RunnerWithScopedPool<Pool, DefaultExecutor> {
+    fn from(pool: Pool) -> Self {
+        Self {
+            pool,
+            runner: PhantomData,
+        }
+    }
+}
+
+impl<'a> From<&'a Pool> for RunnerWithScopedPool<&'a Pool, DefaultExecutor> {
+    fn from(pool: &'a Pool) -> Self {
+        Self {
+            pool,
+            runner: PhantomData,
+        }
+    }
+}
+
+impl<P, R> ParallelRunner for RunnerWithScopedPool<P, R>
+where
+    R: ParallelExecutor,
+    P: SoR<Pool> + ParThreadPool,
+{
+    type Executor = R;
+
+    type ThreadPool = P;
+
+    fn thread_pool(&self) -> &Self::ThreadPool {
+        &self.pool
+    }
+
+    fn thread_pool_mut(&mut self) -> &mut Self::ThreadPool {
+        &mut self.pool
+    }
+}

--- a/src/runner/implementations/scoped_pool.rs
+++ b/src/runner/implementations/scoped_pool.rs
@@ -65,6 +65,7 @@ impl ParThreadPool for &Pool {
 
 // RUNNER
 
+/// Parallel runner using threads provided by scoped_pool::Pool.
 pub struct RunnerWithScopedPool<P, R = DefaultExecutor>
 where
     R: ParallelExecutor,

--- a/src/runner/implementations/scoped_pool.rs
+++ b/src/runner/implementations/scoped_pool.rs
@@ -1,9 +1,6 @@
-use crate::{DefaultExecutor, ParThreadPool, ParallelExecutor, runner::ParallelRunner};
-use core::{marker::PhantomData, num::NonZeroUsize};
-use orx_self_or::SoR;
+use crate::par_thread_pool::ParThreadPool;
+use core::num::NonZeroUsize;
 use scoped_pool::{Pool, Scope};
-
-// POOL
 
 impl ParThreadPool for Pool {
     type ScopeRef<'s, 'env, 'scope>
@@ -60,53 +57,5 @@ impl ParThreadPool for &Pool {
 
     fn max_num_threads(&self) -> core::num::NonZeroUsize {
         NonZeroUsize::new(self.workers().max(1)).expect(">0")
-    }
-}
-
-// RUNNER
-
-/// Parallel runner using threads provided by scoped_pool::Pool.
-pub struct RunnerWithScopedPool<P, R = DefaultExecutor>
-where
-    R: ParallelExecutor,
-    P: SoR<Pool> + ParThreadPool,
-{
-    pool: P,
-    runner: PhantomData<R>,
-}
-
-impl From<Pool> for RunnerWithScopedPool<Pool, DefaultExecutor> {
-    fn from(pool: Pool) -> Self {
-        Self {
-            pool,
-            runner: PhantomData,
-        }
-    }
-}
-
-impl<'a> From<&'a Pool> for RunnerWithScopedPool<&'a Pool, DefaultExecutor> {
-    fn from(pool: &'a Pool) -> Self {
-        Self {
-            pool,
-            runner: PhantomData,
-        }
-    }
-}
-
-impl<P, R> ParallelRunner for RunnerWithScopedPool<P, R>
-where
-    R: ParallelExecutor,
-    P: SoR<Pool> + ParThreadPool,
-{
-    type Executor = R;
-
-    type ThreadPool = P;
-
-    fn thread_pool(&self) -> &Self::ThreadPool {
-        &self.pool
-    }
-
-    fn thread_pool_mut(&mut self) -> &mut Self::ThreadPool {
-        &mut self.pool
     }
 }

--- a/src/runner/implementations/scoped_threadpool.rs
+++ b/src/runner/implementations/scoped_threadpool.rs
@@ -1,11 +1,6 @@
-use crate::{
-    DefaultExecutor, ParallelExecutor, par_thread_pool::ParThreadPool, runner::ParallelRunner,
-};
-use core::{marker::PhantomData, num::NonZeroUsize};
-use orx_self_or::SoM;
+use crate::par_thread_pool::ParThreadPool;
+use core::num::NonZeroUsize;
 use scoped_threadpool::Pool;
-
-// POOL
 
 impl ParThreadPool for Pool {
     type ScopeRef<'s, 'env, 'scope>
@@ -62,53 +57,5 @@ impl ParThreadPool for &mut Pool {
 
     fn max_num_threads(&self) -> NonZeroUsize {
         NonZeroUsize::new((self.thread_count() as usize).max(1)).expect(">0")
-    }
-}
-
-// RUNNER
-
-/// Parallel runner using threads provided by scoped_threadpool::Pool.
-pub struct RunnerWithScopedThreadPool<P, R = DefaultExecutor>
-where
-    R: ParallelExecutor,
-    P: SoM<Pool> + ParThreadPool,
-{
-    pool: P,
-    runner: PhantomData<R>,
-}
-
-impl From<Pool> for RunnerWithScopedThreadPool<Pool, DefaultExecutor> {
-    fn from(pool: Pool) -> Self {
-        Self {
-            pool,
-            runner: PhantomData,
-        }
-    }
-}
-
-impl<'a> From<&'a mut Pool> for RunnerWithScopedThreadPool<&'a mut Pool, DefaultExecutor> {
-    fn from(pool: &'a mut Pool) -> Self {
-        Self {
-            pool,
-            runner: PhantomData,
-        }
-    }
-}
-
-impl<P, R> ParallelRunner for RunnerWithScopedThreadPool<P, R>
-where
-    R: ParallelExecutor,
-    P: SoM<Pool> + ParThreadPool,
-{
-    type Executor = R;
-
-    type ThreadPool = P;
-
-    fn thread_pool(&self) -> &Self::ThreadPool {
-        &self.pool
-    }
-
-    fn thread_pool_mut(&mut self) -> &mut Self::ThreadPool {
-        &mut self.pool
     }
 }

--- a/src/runner/implementations/scoped_threadpool.rs
+++ b/src/runner/implementations/scoped_threadpool.rs
@@ -67,7 +67,7 @@ impl ParThreadPool for &mut Pool {
 
 // RUNNER
 
-/// Parallel runner using threads provided by scoped_threadpool.
+/// Parallel runner using threads provided by scoped_threadpool::Pool.
 pub struct RunnerWithScopedThreadPool<P, R = DefaultExecutor>
 where
     R: ParallelExecutor,

--- a/src/runner/implementations/sequential.rs
+++ b/src/runner/implementations/sequential.rs
@@ -1,7 +1,7 @@
 use crate::ParThreadPool;
 use core::num::NonZeroUsize;
 
-/// A fake thread pool with [`max_num_threads`] of 1.
+/// A 'thread pool' with [`max_num_threads`] of 1.
 /// All computations using this thread pool are executed sequentially by the main thread.
 ///
 /// This is the default thread pool used when "std" feature is disabled.

--- a/src/runner/implementations/sequential.rs
+++ b/src/runner/implementations/sequential.rs
@@ -1,6 +1,15 @@
 use crate::ParThreadPool;
 use core::num::NonZeroUsize;
 
+/// A fake thread pool with [`max_num_threads`] of 1.
+/// All computations using this thread pool are executed sequentially by the main thread.
+///
+/// This is the default thread pool used when "std" feature is disabled.
+/// Note that the thread pool to be used for a parallel computation can be set by the
+/// [`with_runner`] transformation separately for each parallel iterator.
+///
+/// [`max_num_threads`]: ParThreadPool::max_num_threads
+/// [`with_runner`]: crate::ParIter::with_runner
 #[derive(Default)]
 pub struct SequentialPool;
 

--- a/src/runner/implementations/sequential.rs
+++ b/src/runner/implementations/sequential.rs
@@ -1,7 +1,5 @@
-use crate::{DefaultExecutor, ParThreadPool, runner::ParallelRunner};
+use crate::ParThreadPool;
 use core::num::NonZeroUsize;
-
-// POOL
 
 #[derive(Default)]
 pub struct SequentialPool;
@@ -32,32 +30,5 @@ impl ParThreadPool for SequentialPool {
 
     fn max_num_threads(&self) -> NonZeroUsize {
         NonZeroUsize::new(1).expect(">0")
-    }
-}
-
-// RUNNER
-
-/// Sequential runner using using the main thread.
-///
-/// This is the default runner when "std" feature is not enabled.
-///
-/// Parallelization can be achieved by providing a parallel runner
-/// using the [`with_runner`] method of parallel iterators.
-///
-/// [`with_runner`]: crate::ParIter::with_runner
-#[derive(Default)]
-pub struct SequentialRunner(SequentialPool);
-
-impl ParallelRunner for SequentialRunner {
-    type Executor = DefaultExecutor;
-
-    type ThreadPool = SequentialPool;
-
-    fn thread_pool(&self) -> &Self::ThreadPool {
-        &self.0
-    }
-
-    fn thread_pool_mut(&mut self) -> &mut Self::ThreadPool {
-        &mut self.0
     }
 }

--- a/src/runner/implementations/std_runner.rs
+++ b/src/runner/implementations/std_runner.rs
@@ -1,10 +1,5 @@
-use crate::ParallelExecutor;
 use crate::par_thread_pool::ParThreadPool;
-use crate::{DefaultExecutor, runner::ParallelRunner};
-use core::marker::PhantomData;
 use core::num::NonZeroUsize;
-
-// POOL
 
 const MAX_UNSET_NUM_THREADS: NonZeroUsize = NonZeroUsize::new(8).expect(">0");
 
@@ -84,36 +79,5 @@ impl ParThreadPool for &StdDefaultPool {
         W: Fn() + Send + 'scope + 'env,
     {
         s.spawn(work);
-    }
-}
-
-// RUNNER
-
-/// Parallel runner using std threads.
-pub struct StdRunner<E: ParallelExecutor = DefaultExecutor> {
-    pool: StdDefaultPool,
-    executor: PhantomData<E>,
-}
-
-impl Default for StdRunner<DefaultExecutor> {
-    fn default() -> Self {
-        Self {
-            pool: Default::default(),
-            executor: PhantomData,
-        }
-    }
-}
-
-impl<E: ParallelExecutor> ParallelRunner for StdRunner<E> {
-    type Executor = E;
-
-    type ThreadPool = StdDefaultPool;
-
-    fn thread_pool(&self) -> &Self::ThreadPool {
-        &self.pool
-    }
-
-    fn thread_pool_mut(&mut self) -> &mut Self::ThreadPool {
-        &mut self.pool
     }
 }

--- a/src/runner/implementations/std_runner.rs
+++ b/src/runner/implementations/std_runner.rs
@@ -3,6 +3,18 @@ use core::num::NonZeroUsize;
 
 const MAX_UNSET_NUM_THREADS: NonZeroUsize = NonZeroUsize::new(8).expect(">0");
 
+/// Native standard thread pool.
+///
+/// This is the default thread pool used when "std" feature is enabled.
+///
+/// Uses `std::thread::scope` and `scope.spawn(..)` to distribute work to threads.
+///
+/// Its [`max_num_threads`] is determined as the minimum of:
+///
+/// * the available parallelism of the host obtained via `std::thread::available_parallelism()`, and
+/// * the upper bound set by the environment variable "ORX_PARALLEL_MAX_NUM_THREADS", only if set.
+///
+/// [`max_num_threads`]: ParThreadPool::max_num_threads
 pub struct StdDefaultPool {
     max_num_threads: NonZeroUsize,
 }

--- a/src/runner/implementations/std_runner.rs
+++ b/src/runner/implementations/std_runner.rs
@@ -6,15 +6,18 @@ const MAX_UNSET_NUM_THREADS: NonZeroUsize = NonZeroUsize::new(8).expect(">0");
 /// Native standard thread pool.
 ///
 /// This is the default thread pool used when "std" feature is enabled.
+/// Note that the thread pool to be used for a parallel computation can be set by the
+/// [`with_runner`] transformation separately for each parallel iterator.
 ///
 /// Uses `std::thread::scope` and `scope.spawn(..)` to distribute work to threads.
 ///
-/// Its [`max_num_threads`] is determined as the minimum of:
+/// Value of [`max_num_threads`] is determined as the minimum of:
 ///
 /// * the available parallelism of the host obtained via `std::thread::available_parallelism()`, and
-/// * the upper bound set by the environment variable "ORX_PARALLEL_MAX_NUM_THREADS", only if set.
+/// * the upper bound set by the environment variable "ORX_PARALLEL_MAX_NUM_THREADS", when set.
 ///
 /// [`max_num_threads`]: ParThreadPool::max_num_threads
+/// [`with_runner`]: crate::ParIter::with_runner
 pub struct StdDefaultPool {
     max_num_threads: NonZeroUsize,
 }

--- a/src/runner/implementations/tests/mod.rs
+++ b/src/runner/implementations/tests/mod.rs
@@ -4,6 +4,9 @@ mod rayon;
 #[cfg(feature = "scoped_threadpool")]
 mod scoped_threadpool;
 
+#[cfg(feature = "scoped-pool")]
+mod scoped_pool;
+
 #[cfg(feature = "std")]
 mod std;
 

--- a/src/runner/implementations/tests/mod.rs
+++ b/src/runner/implementations/tests/mod.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "pond")]
+mod pond;
+
 #[cfg(feature = "poolite")]
 mod poolite;
+#[cfg(feature = "yastl")]
+mod yastl;
 
 #[cfg(feature = "rayon")]
 mod rayon;

--- a/src/runner/implementations/tests/mod.rs
+++ b/src/runner/implementations/tests/mod.rs
@@ -3,8 +3,6 @@ mod pond;
 
 #[cfg(feature = "poolite")]
 mod poolite;
-#[cfg(feature = "yastl")]
-mod yastl;
 
 #[cfg(feature = "rayon-core")]
 mod rayon_core;

--- a/src/runner/implementations/tests/mod.rs
+++ b/src/runner/implementations/tests/mod.rs
@@ -6,8 +6,8 @@ mod poolite;
 #[cfg(feature = "yastl")]
 mod yastl;
 
-#[cfg(feature = "rayon")]
-mod rayon;
+#[cfg(feature = "rayon-core")]
+mod rayon_core;
 
 #[cfg(feature = "scoped-pool")]
 mod scoped_pool;

--- a/src/runner/implementations/tests/mod.rs
+++ b/src/runner/implementations/tests/mod.rs
@@ -13,6 +13,9 @@ mod scoped_threadpool;
 #[cfg(feature = "std")]
 mod std;
 
+#[cfg(feature = "yastl")]
+mod yastl;
+
 mod sequential;
 
 mod utils;

--- a/src/runner/implementations/tests/mod.rs
+++ b/src/runner/implementations/tests/mod.rs
@@ -1,11 +1,14 @@
+#[cfg(feature = "poolite")]
+mod poolite;
+
 #[cfg(feature = "rayon")]
 mod rayon;
 
-#[cfg(feature = "scoped_threadpool")]
-mod scoped_threadpool;
-
 #[cfg(feature = "scoped-pool")]
 mod scoped_pool;
+
+#[cfg(feature = "scoped_threadpool")]
+mod scoped_threadpool;
 
 #[cfg(feature = "std")]
 mod std;

--- a/src/runner/implementations/tests/pond.rs
+++ b/src/runner/implementations/tests/pond.rs
@@ -1,0 +1,23 @@
+use super::run_map;
+use crate::{
+    IterationOrder,
+    runner::implementations::{PondPool, RunnerWithPondPool},
+};
+use test_case::test_matrix;
+
+#[cfg(miri)]
+const N: [usize; 2] = [37, 125];
+#[cfg(not(miri))]
+const N: [usize; 2] = [1025, 4735];
+
+#[test_matrix(
+    [0, 1, N[0], N[1]],
+    [1, 4],
+    [1, 64],
+    [IterationOrder::Ordered, IterationOrder::Arbitrary])
+]
+fn pool_pond_map(n: usize, nt: usize, chunk: usize, ordering: IterationOrder) {
+    let mut pool = PondPool::new_threads_unbounded(nt);
+    let orch: RunnerWithPondPool<_> = (&mut pool).into();
+    run_map(n, chunk, ordering, orch);
+}

--- a/src/runner/implementations/tests/pond.rs
+++ b/src/runner/implementations/tests/pond.rs
@@ -1,7 +1,7 @@
 use super::run_map;
 use crate::{
     IterationOrder,
-    runner::implementations::{PondPool, RunnerWithPondPool},
+    runner::implementations::{PondPool, RunnerWithPool},
 };
 use test_case::test_matrix;
 
@@ -18,6 +18,6 @@ const N: [usize; 2] = [1025, 4735];
 ]
 fn pool_pond_map(n: usize, nt: usize, chunk: usize, ordering: IterationOrder) {
     let mut pool = PondPool::new_threads_unbounded(nt);
-    let orch: RunnerWithPondPool<_> = (&mut pool).into();
+    let orch: RunnerWithPool<_> = (&mut pool).into();
     run_map(n, chunk, ordering, orch);
 }

--- a/src/runner/implementations/tests/poolite.rs
+++ b/src/runner/implementations/tests/poolite.rs
@@ -1,5 +1,5 @@
 use super::run_map;
-use crate::{IterationOrder, runner::implementations::RunnerWithPoolitePool};
+use crate::{IterationOrder, runner::implementations::RunnerWithPool};
 use poolite::{Builder, Pool};
 use test_case::test_matrix;
 
@@ -16,6 +16,6 @@ const N: [usize; 2] = [1025, 4735];
 ]
 fn pool_poolite_map(n: usize, nt: usize, chunk: usize, ordering: IterationOrder) {
     let pool = Pool::with_builder(Builder::new().max(nt).min(nt)).unwrap();
-    let orch: RunnerWithPoolitePool<_> = (&pool).into();
+    let orch: RunnerWithPool<_> = (&pool).into();
     run_map(n, chunk, ordering, orch);
 }

--- a/src/runner/implementations/tests/poolite.rs
+++ b/src/runner/implementations/tests/poolite.rs
@@ -1,0 +1,21 @@
+use super::run_map;
+use crate::{IterationOrder, runner::implementations::RunnerWithPoolitePool};
+use poolite::{Builder, Pool};
+use test_case::test_matrix;
+
+#[cfg(miri)]
+const N: [usize; 2] = [37, 125];
+#[cfg(not(miri))]
+const N: [usize; 2] = [1025, 4735];
+
+#[test_matrix(
+    [0, 1, N[0], N[1]],
+    [1, 4],
+    [1, 64],
+    [IterationOrder::Ordered, IterationOrder::Arbitrary])
+]
+fn pool_poolite_map(n: usize, nt: usize, chunk: usize, ordering: IterationOrder) {
+    let pool = Pool::with_builder(Builder::new().max(nt).min(nt)).unwrap();
+    let orch: RunnerWithPoolitePool<_> = (&pool).into();
+    run_map(n, chunk, ordering, orch);
+}

--- a/src/runner/implementations/tests/rayon_core.rs
+++ b/src/runner/implementations/tests/rayon_core.rs
@@ -7,7 +7,7 @@ const N: [usize; 2] = [37, 125];
 #[cfg(not(miri))]
 const N: [usize; 2] = [1025, 4735];
 
-// TODO: rayon pool fails the miri test (integer-to-pointer cast crossbeam-epoch-0.9.18/src/atomic.rs:204:11)
+// TODO: rayon_core pool fails the miri test (integer-to-pointer cast crossbeam-epoch-0.9.18/src/atomic.rs:204:11)
 #[cfg(not(miri))]
 #[test_matrix(
     [0, 1, N[0], N[1]],
@@ -16,7 +16,7 @@ const N: [usize; 2] = [1025, 4735];
     [IterationOrder::Ordered, IterationOrder::Arbitrary])
 ]
 fn pool_rayon_map(n: usize, nt: usize, chunk: usize, ordering: IterationOrder) {
-    let pool = rayon::ThreadPoolBuilder::new()
+    let pool = rayon_core::ThreadPoolBuilder::new()
         .num_threads(nt)
         .build()
         .unwrap();

--- a/src/runner/implementations/tests/rayon_core.rs
+++ b/src/runner/implementations/tests/rayon_core.rs
@@ -1,5 +1,5 @@
 use super::run_map;
-use crate::{IterationOrder, runner::implementations::RunnerWithRayonPool};
+use crate::{IterationOrder, runner::implementations::RunnerWithPool};
 use test_case::test_matrix;
 
 #[cfg(miri)]
@@ -20,6 +20,6 @@ fn pool_rayon_map(n: usize, nt: usize, chunk: usize, ordering: IterationOrder) {
         .num_threads(nt)
         .build()
         .unwrap();
-    let orch: RunnerWithRayonPool<_> = (&pool).into();
+    let orch: RunnerWithPool<_> = (&pool).into();
     run_map(n, chunk, ordering, orch);
 }

--- a/src/runner/implementations/tests/scoped_pool.rs
+++ b/src/runner/implementations/tests/scoped_pool.rs
@@ -16,6 +16,6 @@ const N: [usize; 2] = [1025, 4735];
 ]
 fn pool_scoped_pool_map(n: usize, nt: usize, chunk: usize, ordering: IterationOrder) {
     let pool = Pool::new(nt);
-    let orch: RunnerWithPool<_> = (&pool).into();
+    let orch = RunnerWithPool::from(&pool);
     run_map(n, chunk, ordering, orch);
 }

--- a/src/runner/implementations/tests/scoped_pool.rs
+++ b/src/runner/implementations/tests/scoped_pool.rs
@@ -1,5 +1,5 @@
 use super::run_map;
-use crate::{IterationOrder, runner::implementations::RunnerWithScopedPool};
+use crate::{IterationOrder, runner::implementations::RunnerWithPool};
 use scoped_pool::Pool;
 use test_case::test_matrix;
 
@@ -16,6 +16,6 @@ const N: [usize; 2] = [1025, 4735];
 ]
 fn pool_scoped_pool_map(n: usize, nt: usize, chunk: usize, ordering: IterationOrder) {
     let pool = Pool::new(nt);
-    let orch: RunnerWithScopedPool<_> = (&pool).into();
+    let orch: RunnerWithPool<_> = (&pool).into();
     run_map(n, chunk, ordering, orch);
 }

--- a/src/runner/implementations/tests/scoped_pool.rs
+++ b/src/runner/implementations/tests/scoped_pool.rs
@@ -1,0 +1,21 @@
+use super::run_map;
+use crate::{IterationOrder, runner::implementations::RunnerWithScopedPool};
+use scoped_pool::Pool;
+use test_case::test_matrix;
+
+#[cfg(miri)]
+const N: [usize; 2] = [37, 125];
+#[cfg(not(miri))]
+const N: [usize; 2] = [1025, 4735];
+
+#[test_matrix(
+    [0, 1, N[0], N[1]],
+    [1, 4],
+    [1, 64],
+    [IterationOrder::Ordered, IterationOrder::Arbitrary])
+]
+fn pool_scoped_pool_map(n: usize, nt: usize, chunk: usize, ordering: IterationOrder) {
+    let pool = Pool::new(nt);
+    let orch: RunnerWithScopedPool<_> = (&pool).into();
+    run_map(n, chunk, ordering, orch);
+}

--- a/src/runner/implementations/tests/scoped_threadpool.rs
+++ b/src/runner/implementations/tests/scoped_threadpool.rs
@@ -1,5 +1,5 @@
 use super::run_map;
-use crate::{IterationOrder, runner::implementations::RunnerWithScopedThreadPool};
+use crate::{IterationOrder, runner::implementations::RunnerWithPool};
 use scoped_threadpool::Pool;
 use test_case::test_matrix;
 
@@ -16,6 +16,6 @@ const N: [usize; 2] = [1025, 4735];
 ]
 fn pool_scoped_threadpool_map(n: usize, nt: usize, chunk: usize, ordering: IterationOrder) {
     let mut pool = Pool::new(nt as u32);
-    let orch: RunnerWithScopedThreadPool<_> = (&mut pool).into();
+    let orch: RunnerWithPool<_> = (&mut pool).into();
     run_map(n, chunk, ordering, orch);
 }

--- a/src/runner/implementations/tests/sequential.rs
+++ b/src/runner/implementations/tests/sequential.rs
@@ -1,5 +1,5 @@
 use super::run_map;
-use crate::{IterationOrder, runner::implementations::SequentialRunner};
+use crate::{IterationOrder, RunnerWithPool, runner::implementations::sequential::SequentialPool};
 use test_case::test_matrix;
 
 #[cfg(miri)]
@@ -14,6 +14,6 @@ const N: [usize; 2] = [1025, 4735];
     [IterationOrder::Ordered, IterationOrder::Arbitrary])
 ]
 fn pool_scoped_threadpool_map(n: usize, _: usize, chunk: usize, ordering: IterationOrder) {
-    let orch = SequentialRunner::default();
+    let orch = RunnerWithPool::from(SequentialPool);
     run_map(n, chunk, ordering, orch);
 }

--- a/src/runner/implementations/tests/std.rs
+++ b/src/runner/implementations/tests/std.rs
@@ -1,5 +1,7 @@
 use super::run_map;
-use crate::{IterationOrder, StdRunner};
+use crate::{
+    IterationOrder, RunnerWithPool, StdRunner, runner::implementations::std_runner::StdDefaultPool,
+};
 use test_case::test_matrix;
 
 #[cfg(miri)]
@@ -15,5 +17,9 @@ const N: [usize; 2] = [1025, 4735];
 ]
 fn pool_scoped_threadpool_map(n: usize, _: usize, chunk: usize, ordering: IterationOrder) {
     let orch = StdRunner::default();
+    run_map(n, chunk, ordering, orch);
+
+    let pool = StdDefaultPool::default();
+    let orch: RunnerWithPool<_> = (&pool).into();
     run_map(n, chunk, ordering, orch);
 }

--- a/src/runner/implementations/tests/std.rs
+++ b/src/runner/implementations/tests/std.rs
@@ -1,6 +1,7 @@
 use super::run_map;
 use crate::{
-    IterationOrder, RunnerWithPool, StdRunner, runner::implementations::std_runner::StdDefaultPool,
+    DefaultRunner, IterationOrder, RunnerWithPool,
+    runner::implementations::std_runner::StdDefaultPool,
 };
 use test_case::test_matrix;
 
@@ -16,7 +17,7 @@ const N: [usize; 2] = [1025, 4735];
     [IterationOrder::Ordered, IterationOrder::Arbitrary])
 ]
 fn pool_scoped_threadpool_map(n: usize, _: usize, chunk: usize, ordering: IterationOrder) {
-    let orch = StdRunner::default();
+    let orch = DefaultRunner::default();
     run_map(n, chunk, ordering, orch);
 
     let pool = StdDefaultPool::default();

--- a/src/runner/implementations/tests/yastl.rs
+++ b/src/runner/implementations/tests/yastl.rs
@@ -1,7 +1,7 @@
 use super::run_map;
 use crate::{
     IterationOrder,
-    runner::implementations::{RunnerWithYastlPool, YastlPool},
+    runner::implementations::{RunnerWithPool, YastlPool},
 };
 use test_case::test_matrix;
 use yastl::ThreadConfig;
@@ -19,10 +19,10 @@ const N: [usize; 2] = [1025, 4735];
 ]
 fn pool_yastl_map(n: usize, nt: usize, chunk: usize, ordering: IterationOrder) {
     let pool = YastlPool::new(nt);
-    let orch: RunnerWithYastlPool<_> = (&pool).into();
+    let orch: RunnerWithPool<_> = (&pool).into();
     run_map(n, chunk, ordering, orch);
 
     let pool = YastlPool::with_config(nt, ThreadConfig::new());
-    let orch: RunnerWithYastlPool<_> = (&pool).into();
+    let orch: RunnerWithPool<_> = (&pool).into();
     run_map(n, chunk, ordering, orch);
 }

--- a/src/runner/implementations/tests/yastl.rs
+++ b/src/runner/implementations/tests/yastl.rs
@@ -1,0 +1,28 @@
+use super::run_map;
+use crate::{
+    IterationOrder,
+    runner::implementations::{RunnerWithYastlPool, YastlPool},
+};
+use test_case::test_matrix;
+use yastl::ThreadConfig;
+
+#[cfg(miri)]
+const N: [usize; 2] = [37, 125];
+#[cfg(not(miri))]
+const N: [usize; 2] = [1025, 4735];
+
+#[test_matrix(
+    [0, 1, N[0], N[1]],
+    [1, 4],
+    [1, 64],
+    [IterationOrder::Ordered, IterationOrder::Arbitrary])
+]
+fn pool_yastl_map(n: usize, nt: usize, chunk: usize, ordering: IterationOrder) {
+    let pool = YastlPool::new(nt);
+    let orch: RunnerWithYastlPool<_> = (&pool).into();
+    run_map(n, chunk, ordering, orch);
+
+    let pool = YastlPool::with_config(nt, ThreadConfig::new());
+    let orch: RunnerWithYastlPool<_> = (&pool).into();
+    run_map(n, chunk, ordering, orch);
+}

--- a/src/runner/implementations/yastl.rs
+++ b/src/runner/implementations/yastl.rs
@@ -5,29 +5,44 @@ use yastl::{Pool, Scope, ThreadConfig};
 
 // POOL
 
+/// A wrapper for `yastl::Pool` and number of threads it was built with.
+///
+/// NOTE: The reason why `yastl::Pool` does not directly implement `ParThreadPool`
+/// is simply to be able to provide `max_num_threads` which is the argument used
+/// to create the pool with.
+///
+/// Two constructors of the `yastl::Pool` are made available to `YastlPool` as well:
+/// * [`YastlPool::new`]
+/// * [`YastlPool::with_config`]
 pub struct YastlPool(Pool, NonZeroUsize);
 
 impl YastlPool {
+    /// Create a new Pool that will execute it's tasks on `num_threads` worker threads.
     pub fn new(num_threads: usize) -> Self {
         let num_threads = num_threads.min(1);
         let pool = Pool::new(num_threads);
         Self(pool, NonZeroUsize::new(num_threads).expect(">0"))
     }
 
+    /// Create a new Pool that will execute it's tasks on `num_threads` worker threads and
+    /// spawn them using the given `config`.
     pub fn with_config(num_threads: usize, config: ThreadConfig) -> Self {
         let num_threads = num_threads.min(1);
         let pool = Pool::with_config(num_threads, config);
         Self(pool, NonZeroUsize::new(num_threads).expect(">0"))
     }
 
+    /// Reference to wrapped `yastl::Pool`.
     pub fn inner(&self) -> &Pool {
         &self.0
     }
 
+    /// Mutable reference to wrapped `yastl::Pool`.
     pub fn inner_mut(&mut self) -> &mut Pool {
         &mut self.0
     }
 
+    /// Returns the wrapped `yastl::Pool`.
     pub fn into_inner(self) -> Pool {
         self.0
     }

--- a/src/runner/implementations/yastl.rs
+++ b/src/runner/implementations/yastl.rs
@@ -18,6 +18,7 @@ impl YastlPool {
     pub fn new(num_threads: usize) -> Self {
         let num_threads = num_threads.min(1);
         let pool = Pool::new(num_threads);
+        #[allow(clippy::missing_panics_doc)]
         Self(pool, NonZeroUsize::new(num_threads).expect(">0"))
     }
 
@@ -26,6 +27,7 @@ impl YastlPool {
     pub fn with_config(num_threads: usize, config: ThreadConfig) -> Self {
         let num_threads = num_threads.min(1);
         let pool = Pool::with_config(num_threads, config);
+        #[allow(clippy::missing_panics_doc)]
         Self(pool, NonZeroUsize::new(num_threads).expect(">0"))
     }
 

--- a/src/runner/implementations/yastl.rs
+++ b/src/runner/implementations/yastl.rs
@@ -1,9 +1,6 @@
-use crate::{DefaultExecutor, ParThreadPool, ParallelExecutor, runner::ParallelRunner};
-use core::{marker::PhantomData, num::NonZeroUsize};
-use orx_self_or::SoR;
+use crate::ParThreadPool;
+use core::num::NonZeroUsize;
 use yastl::{Pool, Scope, ThreadConfig};
-
-// POOL
 
 /// A wrapper for `yastl::Pool` and number of threads it was built with.
 ///
@@ -103,53 +100,5 @@ impl ParThreadPool for &YastlPool {
 
     fn max_num_threads(&self) -> NonZeroUsize {
         self.1
-    }
-}
-
-// RUNNER
-
-/// Parallel runner using threads provided by yastl::Pool.
-pub struct RunnerWithYastlPool<P, R = DefaultExecutor>
-where
-    R: ParallelExecutor,
-    P: SoR<YastlPool> + ParThreadPool,
-{
-    pool: P,
-    runner: PhantomData<R>,
-}
-
-impl From<YastlPool> for RunnerWithYastlPool<YastlPool, DefaultExecutor> {
-    fn from(pool: YastlPool) -> Self {
-        Self {
-            pool,
-            runner: PhantomData,
-        }
-    }
-}
-
-impl<'a> From<&'a YastlPool> for RunnerWithYastlPool<&'a YastlPool, DefaultExecutor> {
-    fn from(pool: &'a YastlPool) -> Self {
-        Self {
-            pool,
-            runner: PhantomData,
-        }
-    }
-}
-
-impl<P, R> ParallelRunner for RunnerWithYastlPool<P, R>
-where
-    R: ParallelExecutor,
-    P: SoR<YastlPool> + ParThreadPool,
-{
-    type Executor = R;
-
-    type ThreadPool = P;
-
-    fn thread_pool(&self) -> &Self::ThreadPool {
-        &self.pool
-    }
-
-    fn thread_pool_mut(&mut self) -> &mut Self::ThreadPool {
-        &mut self.pool
     }
 }

--- a/src/runner/implementations/yastl.rs
+++ b/src/runner/implementations/yastl.rs
@@ -1,0 +1,140 @@
+use crate::{DefaultExecutor, ParThreadPool, ParallelExecutor, runner::ParallelRunner};
+use core::{marker::PhantomData, num::NonZeroUsize};
+use orx_self_or::SoR;
+use yastl::{Pool, Scope, ThreadConfig};
+
+// POOL
+
+pub struct YastlPool(Pool, NonZeroUsize);
+
+impl YastlPool {
+    pub fn new(num_threads: usize) -> Self {
+        let num_threads = num_threads.min(1);
+        let pool = Pool::new(num_threads);
+        Self(pool, NonZeroUsize::new(num_threads).expect(">0"))
+    }
+
+    pub fn with_config(num_threads: usize, config: ThreadConfig) -> Self {
+        let num_threads = num_threads.min(1);
+        let pool = Pool::with_config(num_threads, config);
+        Self(pool, NonZeroUsize::new(num_threads).expect(">0"))
+    }
+
+    pub fn inner(&self) -> &Pool {
+        &self.0
+    }
+
+    pub fn inner_mut(&mut self) -> &mut Pool {
+        &mut self.0
+    }
+
+    pub fn into_inner(self) -> Pool {
+        self.0
+    }
+}
+
+impl ParThreadPool for YastlPool {
+    type ScopeRef<'s, 'env, 'scope>
+        = &'s Scope<'scope>
+    where
+        'scope: 's,
+        'env: 'scope + 's;
+
+    fn run_in_scope<'s, 'env, 'scope, W>(s: &Self::ScopeRef<'s, 'env, 'scope>, work: W)
+    where
+        'scope: 's,
+        'env: 'scope + 's,
+        W: Fn() + Send + 'scope + 'env,
+    {
+        s.execute(work);
+    }
+
+    fn scoped_computation<'env, 'scope, F>(&'env mut self, f: F)
+    where
+        'env: 'scope,
+        for<'s> F: FnOnce(&'s Scope<'scope>) + Send,
+    {
+        self.0.scoped(f)
+    }
+
+    fn max_num_threads(&self) -> NonZeroUsize {
+        self.1
+    }
+}
+
+impl ParThreadPool for &YastlPool {
+    type ScopeRef<'s, 'env, 'scope>
+        = &'s Scope<'scope>
+    where
+        'scope: 's,
+        'env: 'scope + 's;
+
+    fn run_in_scope<'s, 'env, 'scope, W>(s: &Self::ScopeRef<'s, 'env, 'scope>, work: W)
+    where
+        'scope: 's,
+        'env: 'scope + 's,
+        W: Fn() + Send + 'scope + 'env,
+    {
+        s.execute(work);
+    }
+
+    fn scoped_computation<'env, 'scope, F>(&'env mut self, f: F)
+    where
+        'env: 'scope,
+        for<'s> F: FnOnce(&'s Scope<'scope>) + Send,
+    {
+        self.0.scoped(f)
+    }
+
+    fn max_num_threads(&self) -> NonZeroUsize {
+        self.1
+    }
+}
+
+// RUNNER
+
+/// Parallel runner using threads provided by yastl::Pool.
+pub struct RunnerWithYastlPool<P, R = DefaultExecutor>
+where
+    R: ParallelExecutor,
+    P: SoR<YastlPool> + ParThreadPool,
+{
+    pool: P,
+    runner: PhantomData<R>,
+}
+
+impl From<YastlPool> for RunnerWithYastlPool<YastlPool, DefaultExecutor> {
+    fn from(pool: YastlPool) -> Self {
+        Self {
+            pool,
+            runner: PhantomData,
+        }
+    }
+}
+
+impl<'a> From<&'a YastlPool> for RunnerWithYastlPool<&'a YastlPool, DefaultExecutor> {
+    fn from(pool: &'a YastlPool) -> Self {
+        Self {
+            pool,
+            runner: PhantomData,
+        }
+    }
+}
+
+impl<P, R> ParallelRunner for RunnerWithYastlPool<P, R>
+where
+    R: ParallelExecutor,
+    P: SoR<YastlPool> + ParThreadPool,
+{
+    type Executor = R;
+
+    type ThreadPool = P;
+
+    fn thread_pool(&self) -> &Self::ThreadPool {
+        &self.pool
+    }
+
+    fn thread_pool_mut(&mut self) -> &mut Self::ThreadPool {
+        &mut self.pool
+    }
+}

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -20,7 +20,7 @@ pub use implementations::{PondPool, RunnerWithPondPool};
 #[cfg(feature = "poolite")]
 pub use implementations::RunnerWithPoolitePool;
 
-#[cfg(feature = "rayon")]
+#[cfg(feature = "rayon-core")]
 pub use implementations::RunnerWithRayonPool;
 
 #[cfg(feature = "scoped-pool")]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -14,14 +14,17 @@ pub use implementations::SequentialRunner;
 #[cfg(feature = "std")]
 pub use implementations::StdRunner;
 
+#[cfg(feature = "poolite")]
+pub use implementations::RunnerWithPoolitePool;
+
 #[cfg(feature = "rayon")]
 pub use implementations::RunnerWithRayonPool;
 
-#[cfg(feature = "scoped_threadpool")]
-pub use implementations::RunnerWithScopedThreadPool;
-
 #[cfg(feature = "scoped-pool")]
 pub use implementations::RunnerWithScopedPool;
+
+#[cfg(feature = "scoped_threadpool")]
+pub use implementations::RunnerWithScopedThreadPool;
 
 // DEFAULT
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -26,6 +26,9 @@ pub use implementations::RunnerWithScopedPool;
 #[cfg(feature = "scoped_threadpool")]
 pub use implementations::RunnerWithScopedThreadPool;
 
+#[cfg(feature = "yastl")]
+pub use implementations::{RunnerWithYastlPool, YastlPool};
+
 // DEFAULT
 
 /// Default runner used by orx-parallel computations:

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -9,7 +9,7 @@ pub use computation_kind::ComputationKind;
 pub use num_spawned::NumSpawned;
 pub use parallel_runner::ParallelRunner;
 
-pub use implementations::SequentialRunner;
+pub use implementations::{RunnerWithPool, SequentialRunner};
 
 #[cfg(feature = "std")]
 pub use implementations::StdRunner;

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -6,43 +6,30 @@ mod parallel_runner;
 pub(crate) use parallel_runner::{SharedStateOf, ThreadRunnerOf};
 
 pub use computation_kind::ComputationKind;
+pub use implementations::{RunnerWithPool, SequentialPool};
 pub use num_spawned::NumSpawned;
 pub use parallel_runner::ParallelRunner;
 
-pub use implementations::{RunnerWithPool, SequentialRunner};
+#[cfg(feature = "pond")]
+pub use implementations::PondPool;
 
 #[cfg(feature = "std")]
-pub use implementations::StdRunner;
-
-#[cfg(feature = "pond")]
-pub use implementations::{PondPool, RunnerWithPondPool};
-
-#[cfg(feature = "poolite")]
-pub use implementations::RunnerWithPoolitePool;
-
-#[cfg(feature = "rayon-core")]
-pub use implementations::RunnerWithRayonPool;
-
-#[cfg(feature = "scoped-pool")]
-pub use implementations::RunnerWithScopedPool;
-
-#[cfg(feature = "scoped_threadpool")]
-pub use implementations::RunnerWithScopedThreadPool;
+pub use implementations::StdDefaultPool;
 
 #[cfg(feature = "yastl")]
-pub use implementations::{RunnerWithYastlPool, YastlPool};
+pub use implementations::YastlPool;
 
 // DEFAULT
 
 /// Default runner used by orx-parallel computations:
 ///
-/// * [`StdRunner`] when "std" feature is enabled,
-/// * `SequentialRunner` otherwise.
+/// * [`RunnerWithPool`] with [`StdDefaultPool`] when "std" feature is enabled,
+/// * [`RunnerWithPool`] with `SequentialPool` otherwise.
 #[cfg(feature = "std")]
-pub type DefaultRunner = StdRunner;
+pub type DefaultRunner = RunnerWithPool<StdDefaultPool>;
 /// Default runner used by orx-parallel computations:
 ///
-/// * `StdRunner` when "std" feature is enabled,
-/// * [`SequentialRunner`] otherwise.
+/// * [`RunnerWithPool`] with `StdDefaultPool` when "std" feature is enabled,
+/// * [`RunnerWithPool`] with [`SequentialPool`] otherwise.
 #[cfg(not(feature = "std"))]
-pub type DefaultRunner = SequentialRunner;
+pub type DefaultRunner = RunnerWithPool<SequentialPool>;

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -24,7 +24,7 @@ pub use implementations::YastlPool;
 /// Default runner used by orx-parallel computations:
 ///
 /// * [`RunnerWithPool`] with [`StdDefaultPool`] when "std" feature is enabled,
-/// * [`RunnerWithPool`] with `SequentialPool` otherwise.
+/// * [`RunnerWithPool`] with [`SequentialPool`] otherwise.
 #[cfg(feature = "std")]
 pub type DefaultRunner = RunnerWithPool<StdDefaultPool>;
 /// Default runner used by orx-parallel computations:

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -20,6 +20,11 @@ pub use implementations::RunnerWithRayonPool;
 #[cfg(feature = "scoped_threadpool")]
 pub use implementations::RunnerWithScopedThreadPool;
 
+#[cfg(feature = "scoped-pool")]
+pub use implementations::RunnerWithScopedPool;
+
+// DEFAULT
+
 /// Default runner used by orx-parallel computations:
 ///
 /// * [`StdRunner`] when "std" feature is enabled,

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -21,15 +21,21 @@ pub use implementations::YastlPool;
 
 // DEFAULT
 
-/// Default runner used by orx-parallel computations:
+/// Default pool used by orx-parallel computations:
+///
+/// * [`StdDefaultPool`] when "std" feature is enabled,
+/// * [`SequentialPool`] otherwise.
+#[cfg(feature = "std")]
+pub type DefaultPool = StdDefaultPool;
+/// Default pool used by orx-parallel computations:
+///
+/// * `StdDefaultPool` when "std" feature is enabled,
+/// * [`SequentialPool`] otherwise.
+#[cfg(not(feature = "std"))]
+pub type DefaultPool = SequentialPool;
+
+/// Default runner used by orx-parallel computations, using the [`DefaultPool`]:
 ///
 /// * [`RunnerWithPool`] with [`StdDefaultPool`] when "std" feature is enabled,
 /// * [`RunnerWithPool`] with [`SequentialPool`] otherwise.
-#[cfg(feature = "std")]
-pub type DefaultRunner = RunnerWithPool<StdDefaultPool>;
-/// Default runner used by orx-parallel computations:
-///
-/// * [`RunnerWithPool`] with `StdDefaultPool` when "std" feature is enabled,
-/// * [`RunnerWithPool`] with [`SequentialPool`] otherwise.
-#[cfg(not(feature = "std"))]
-pub type DefaultRunner = RunnerWithPool<SequentialPool>;
+pub type DefaultRunner = RunnerWithPool<DefaultPool>;

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -14,6 +14,9 @@ pub use implementations::SequentialRunner;
 #[cfg(feature = "std")]
 pub use implementations::StdRunner;
 
+#[cfg(feature = "pond")]
+pub use implementations::{PondPool, RunnerWithPondPool};
+
 #[cfg(feature = "poolite")]
 pub use implementations::RunnerWithPoolitePool;
 

--- a/src/using/u_par_iter.rs
+++ b/src/using/u_par_iter.rs
@@ -61,6 +61,7 @@ where
     /// See [`ParIter::with_runner`] for details.
     ///
     /// [`DefaultRunner`]: crate::DefaultRunner
+    /// [`ParIter::with_runner`]: crate::ParIter::with_runner
     fn with_runner<Q: ParallelRunner>(
         self,
         orchestrator: Q,
@@ -72,6 +73,7 @@ where
     /// See [`ParIter::with_pool`] for details.
     ///
     /// [`DefaultPool`]: crate::DefaultPool
+    /// [`ParIter::with_pool`]: crate::ParIter::with_pool
     fn with_pool<P: ParThreadPool>(
         self,
         pool: P,


### PR DESCRIPTION
`ParThreadPool` is implemented for various thread pool implementations. These are defined as optional dependencies. Current list is as follows:

* Std,
* Sequential,
* Pond,
* Poolite,
* RayonCore,
* ScopedPool,
* ScopedThreadPool,
* Yastl,

Generic `RunnerWithPool` is defined which implements `ParallelRunner`.

Default parallel runner, parallel executor and thread pool are defined.

The crate is converted into a "no-std" crate while "std" is added as a default feature. When "std" is disabled, sequential (fake) thread pool is used as the default thread pool. In this case, the caller might provide a thread pool to enable parallelization.

`with_runner` transformation is revised.

`with_pool` transformation is added as a convenient shorthand. It allows to pass in a pool or a reference to a pool to be used for the given parallel computaiton.

"examples/benchmark_pools.rs" example is created to have a lightweight and quick comparison of performances among different thread pools.

`cargo run --all-features --release --example benchmark_pools`

In the current example, the following results are obtained:

```rust
// Args { pool_type: All, num_threads: 16, len: 100000, num_repetitions: 1000 }
// Std => 15.912437916s
// Sequential => 46.194610858s
// Pond => 42.560279289s
// Poolite => 21.422590826s
// RayonCore => 16.227641997s
// ScopedPool => 15.958834105s
// ScopedThreadPool => 17.228307255s
// Yastl => 43.914882593s
```