### PR TITLE
Add enumerate to parallel iterators

### DIFF
--- a/src/computational_variants/par.rs
+++ b/src/computational_variants/par.rs
@@ -8,7 +8,7 @@ use crate::using::{UPar, UsingClone, UsingFun};
 use crate::{
     ChunkSize, IterationOrder, NumThreads, ParCollectInto, ParIter, Params, default_fns::map_self,
 };
-use crate::{IntoParIter, ParIterResult, ParIterUsing};
+use crate::{IntoParIter, ParEnumerate, ParIterResult, ParIterUsing};
 use orx_concurrent_iter::chain::ChainKnownLenI;
 use orx_concurrent_iter::{ConcurrentIter, ExactSizeConcurrentIter};
 
@@ -238,5 +238,16 @@ where
         let (orchestrator, params, iter) = self.destruct();
         let iter = iter.chain(other.into_con_iter());
         Par::new(orchestrator, params, iter)
+    }
+}
+
+impl<I, R> ParEnumerate<R> for Par<I, R>
+where
+    R: ParallelRunner,
+    I: ConcurrentIter,
+{
+    fn enumerate(self) -> impl ParIter<R, Item = (usize, Self::Item)> {
+        let (orchestrator, params, iter) = self.destruct();
+        Par::new(orchestrator, params, iter.enumerate())
     }
 }

--- a/src/computational_variants/tests/enumerate.rs
+++ b/src/computational_variants/tests/enumerate.rs
@@ -1,0 +1,55 @@
+use std::string::ToString;
+
+use crate::{test_utils::*, *};
+use alloc::vec::Vec;
+use test_case::test_matrix;
+
+#[test_matrix(N, NT, CHUNK)]
+fn enumerate_sequential(n: &[usize], nt: &[usize], chunk: &[usize]) {
+    let test = |n, nt, chunk| {
+        let par = (0..n).into_par().num_threads(nt).chunk_size(chunk);
+        let par = par.enumerate();
+        let vec: Vec<_> = par.collect();
+
+        vec.iter().for_each(|(idx, value)| {
+            assert_eq!(idx, value);
+        });
+    };
+    test_n_nt_chunk(n, nt, chunk, test);
+}
+
+#[test_matrix(N, NT, CHUNK)]
+fn enumerate_map(n: &[usize], nt: &[usize], chunk: &[usize]) {
+    let test = |n, nt, chunk| {
+        let par = (0..n).into_par().num_threads(nt).chunk_size(chunk);
+        let par = par
+            .enumerate()
+            .map(|(idx, value): (usize, usize)| (idx + 1, value.pow(2)));
+        let vec: Vec<_> = par.collect();
+
+        vec.iter().for_each(|(idx_outer, value)| {
+            assert_eq!((*idx_outer - 1).pow(2), *value);
+        });
+    };
+    test_n_nt_chunk(n, nt, chunk, test);
+}
+
+#[test_matrix(N, NT, CHUNK)]
+fn enumerate_using(n: &[usize], nt: &[usize], chunk: &[usize]) {
+    let test = |n, nt, chunk| {
+        let par = (0..n)
+            .into_par()
+            .num_threads(nt)
+            .chunk_size(chunk)
+            .enumerate()
+            .using_clone("XyZw".to_string());
+
+        let par = par.map(|_u, (idx, value)| (idx + 1, value.pow(2)));
+        let vec: Vec<_> = par.collect();
+
+        vec.iter().for_each(|(idx_outer, value)| {
+            assert_eq!((idx_outer - 1).pow(2), *value);
+        });
+    };
+    test_n_nt_chunk(n, nt, chunk, test);
+}

--- a/src/computational_variants/tests/mod.rs
+++ b/src/computational_variants/tests/mod.rs
@@ -1,5 +1,6 @@
 mod copied;
 mod count;
+mod enumerate;
 mod fallible_option;
 mod fallible_result;
 mod flatten;

--- a/src/enumerate/mod.rs
+++ b/src/enumerate/mod.rs
@@ -1,0 +1,22 @@
+use crate::{ParIter, ParallelRunner};
+
+/// A parallel iterator with a known and fixed size,
+/// meaning all transformations are 1 to 1.
+pub trait ParEnumerate<R: ParallelRunner>: ParIter<R> {
+    /// Creates an iterator which gives each value along with its index in the source collection.
+    ///
+    /// The iterator returned yields pairs `(i, val)`, where `i` is the index in the source collection,
+    /// and `val` is the value returned by the iterator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use orx_parallel::*;
+    ///
+    /// let vec = vec![26i32, -27, 5];
+    ///
+    /// let max_abs = vec.into_par().enumerate().max_by_key(|(_idx, x)| x.abs());
+    /// assert_eq!(max_abs, Some((1, -27)));
+    /// ```
+    fn enumerate(self) -> impl ParIter<R, Item = (usize, Self::Item)>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod collect_into;
 /// Module containing variants of parallel iterators.
 pub mod computational_variants;
 mod default_fns;
+mod enumerate;
 mod env;
 /// Module defining the parallel runner trait and the default parallel runner.
 pub mod executor;
@@ -63,6 +64,7 @@ pub use orx_concurrent_recursive_iter::Queue;
 // export
 
 pub use collect_into::ParCollectInto;
+pub use enumerate::ParEnumerate;
 pub use executor::{DefaultExecutor, ParallelExecutor, ThreadExecutor};
 pub use into_par_iter::IntoParIter;
 pub use iter::IntoParIterRec;


### PR DESCRIPTION
Closes #35 as part of my ongoing effort to port wild to orx-parallel (https://github.com/davidlattimore/wild/pull/1413). Let me know if you think the tests I've added here are sufficient.

If you have time, I'd also appreciate your input on the PR I linked above, as performance seems to have gone down in some cases when using orx-parallel, so I'm likely not using it optimally.