### PR TITLE
iter of iter uses fixed chunk heuristic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["concurrency", "algorithms"]
 orx-iterable = { version = "1.3", default-features = false }
 orx-pseudo-default = { version = "2.1", default-features = false }
 orx-priority-queue = { version = "1.9", default-features = false }
-orx-concurrent-iter = { version = "4.1", default-features = false }
+orx-concurrent-iter = { version = "4.3", default-features = false }
 orx-pinned-vec = { version = "4.0", default-features = false }
 orx-fixed-vec = { version = "4.0", default-features = false }
 orx-split-vec = { version = "4.0", default-features = false }

--- a/src/infallible/par_runner.rs
+++ b/src/infallible/par_runner.rs
@@ -23,7 +23,8 @@ pub(crate) trait ParRunnerInfallible: ParRunner {
                 .map(|(idx, val)| ValIdx::new(val, idx)),
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), None);
+                let (max_nt, state) =
+                    self.nt_state(params, I::is_source_serialized(), iter.size_hint(), None);
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results, x) = (&iter, &state, &results_bag, x);
@@ -58,7 +59,8 @@ pub(crate) trait ParRunnerInfallible: ParRunner {
                 .next(),
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), None);
+                let (max_nt, state) =
+                    self.nt_state(params, I::is_source_serialized(), iter.size_hint(), None);
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results, x) = (&iter, &state, &results_bag, x);
@@ -94,7 +96,8 @@ pub(crate) trait ParRunnerInfallible: ParRunner {
                 .reduce(f),
             _ => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), None);
+                let (max_nt, state) =
+                    self.nt_state(params, I::is_source_serialized(), iter.size_hint(), None);
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results, x) = (&iter, &state, &results_bag, x);
@@ -132,7 +135,8 @@ pub(crate) trait ParRunnerInfallible: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), None);
+                let (max_nt, state) =
+                    self.nt_state(params, I::is_source_serialized(), iter.size_hint(), None);
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results) = (&iter, &state, &results_bag);
@@ -168,7 +172,8 @@ pub(crate) trait ParRunnerInfallible: ParRunner {
             ],
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), None);
+                let (max_nt, state) =
+                    self.nt_state(params, I::is_source_serialized(), iter.size_hint(), None);
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results) = (&iter, &state, &results_bag);
@@ -208,7 +213,7 @@ pub(crate) trait ParRunnerInfallible: ParRunner {
         };
 
         let mut spawned = 0;
-        let (_, state) = self.nt_state(params, iter.size_hint(), None);
+        let (_, state) = self.nt_state(params, &iter, iter.size_hint(), None);
 
         let (iter, st, bag) = (&iter, &state, &results_bag);
         self.pool_mut().scoped_computation(move |s| {

--- a/src/infallible_use/par_runner.rs
+++ b/src/infallible_use/par_runner.rs
@@ -28,7 +28,12 @@ pub trait ParRunnerInfallibleUse: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), u.max_threads());
+                let (max_nt, state) = self.nt_state(
+                    params,
+                    I::is_source_serialized(),
+                    iter.size_hint(),
+                    u.max_threads(),
+                );
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results, x, u) = (&iter, &state, &results_bag, x, &u);
@@ -67,7 +72,12 @@ pub trait ParRunnerInfallibleUse: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), u.max_threads());
+                let (max_nt, state) = self.nt_state(
+                    params,
+                    I::is_source_serialized(),
+                    iter.size_hint(),
+                    u.max_threads(),
+                );
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results, x, u) = (&iter, &state, &results_bag, x, &u);
@@ -107,7 +117,12 @@ pub trait ParRunnerInfallibleUse: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), u.max_threads());
+                let (max_nt, state) = self.nt_state(
+                    params,
+                    I::is_source_serialized(),
+                    iter.size_hint(),
+                    u.max_threads(),
+                );
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 {
@@ -152,7 +167,12 @@ pub trait ParRunnerInfallibleUse: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), u.max_threads());
+                let (max_nt, state) = self.nt_state(
+                    params,
+                    I::is_source_serialized(),
+                    iter.size_hint(),
+                    u.max_threads(),
+                );
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results, u) = (&iter, &state, &results_bag, &u);
@@ -193,7 +213,12 @@ pub trait ParRunnerInfallibleUse: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), u.max_threads());
+                let (max_nt, state) = self.nt_state(
+                    params,
+                    I::is_source_serialized(),
+                    iter.size_hint(),
+                    u.max_threads(),
+                );
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results, u) = (&iter, &state, &results_bag, &u);

--- a/src/option/par_runner.rs
+++ b/src/option/par_runner.rs
@@ -41,7 +41,8 @@ pub trait ParRunnerOpt: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), None);
+                let (max_nt, state) =
+                    self.nt_state(params, I::is_source_serialized(), iter.size_hint(), None);
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results) = (&iter, &state, &results_bag);
@@ -91,7 +92,8 @@ pub trait ParRunnerOpt: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), None);
+                let (max_nt, state) =
+                    self.nt_state(params, I::is_source_serialized(), iter.size_hint(), None);
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results) = (&iter, &state, &results_bag);
@@ -149,7 +151,8 @@ pub trait ParRunnerOpt: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), None);
+                let (max_nt, state) =
+                    self.nt_state(params, I::is_source_serialized(), iter.size_hint(), None);
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results) = (&iter, &state, &results_bag);
@@ -200,7 +203,8 @@ pub trait ParRunnerOpt: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), None);
+                let (max_nt, state) =
+                    self.nt_state(params, I::is_source_serialized(), iter.size_hint(), None);
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results) = (&iter, &state, &results_bag);
@@ -251,7 +255,8 @@ pub trait ParRunnerOpt: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), None);
+                let (max_nt, state) =
+                    self.nt_state(params, I::is_source_serialized(), iter.size_hint(), None);
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results) = (&iter, &state, &results_bag);

--- a/src/option_use/par_runner.rs
+++ b/src/option_use/par_runner.rs
@@ -47,7 +47,12 @@ pub trait ParRunnerUseOpt: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), u.max_threads());
+                let (max_nt, state) = self.nt_state(
+                    params,
+                    I::is_source_serialized(),
+                    iter.size_hint(),
+                    u.max_threads(),
+                );
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results, u) = (&iter, &state, &results_bag, &u);
@@ -103,7 +108,12 @@ pub trait ParRunnerUseOpt: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), u.max_threads());
+                let (max_nt, state) = self.nt_state(
+                    params,
+                    I::is_source_serialized(),
+                    iter.size_hint(),
+                    u.max_threads(),
+                );
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results, u) = (&iter, &state, &results_bag, &u);
@@ -167,7 +177,12 @@ pub trait ParRunnerUseOpt: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), u.max_threads());
+                let (max_nt, state) = self.nt_state(
+                    params,
+                    I::is_source_serialized(),
+                    iter.size_hint(),
+                    u.max_threads(),
+                );
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 {
@@ -226,7 +241,12 @@ pub trait ParRunnerUseOpt: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), u.max_threads());
+                let (max_nt, state) = self.nt_state(
+                    params,
+                    I::is_source_serialized(),
+                    iter.size_hint(),
+                    u.max_threads(),
+                );
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results, u) = (&iter, &state, &results_bag, &u);
@@ -282,7 +302,12 @@ pub trait ParRunnerUseOpt: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), u.max_threads());
+                let (max_nt, state) = self.nt_state(
+                    params,
+                    I::is_source_serialized(),
+                    iter.size_hint(),
+                    u.max_threads(),
+                );
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results, u) = (&iter, &state, &results_bag, &u);

--- a/src/result/par_runner.rs
+++ b/src/result/par_runner.rs
@@ -42,7 +42,8 @@ pub trait ParRunnerRes: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), None);
+                let (max_nt, state) =
+                    self.nt_state(params, I::is_source_serialized(), iter.size_hint(), None);
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results) = (&iter, &state, &results_bag);
@@ -97,7 +98,8 @@ pub trait ParRunnerRes: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), None);
+                let (max_nt, state) =
+                    self.nt_state(params, I::is_source_serialized(), iter.size_hint(), None);
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results) = (&iter, &state, &results_bag);
@@ -157,7 +159,8 @@ pub trait ParRunnerRes: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), None);
+                let (max_nt, state) =
+                    self.nt_state(params, I::is_source_serialized(), iter.size_hint(), None);
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results) = (&iter, &state, &results_bag);
@@ -210,7 +213,8 @@ pub trait ParRunnerRes: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), None);
+                let (max_nt, state) =
+                    self.nt_state(params, I::is_source_serialized(), iter.size_hint(), None);
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results) = (&iter, &state, &results_bag);
@@ -263,7 +267,8 @@ pub trait ParRunnerRes: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), None);
+                let (max_nt, state) =
+                    self.nt_state(params, I::is_source_serialized(), iter.size_hint(), None);
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results) = (&iter, &state, &results_bag);

--- a/src/result_use/par_runner.rs
+++ b/src/result_use/par_runner.rs
@@ -48,7 +48,12 @@ pub trait ParRunnerUseRes: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), u.max_threads());
+                let (max_nt, state) = self.nt_state(
+                    params,
+                    I::is_source_serialized(),
+                    iter.size_hint(),
+                    u.max_threads(),
+                );
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results, u) = (&iter, &state, &results_bag, &u);
@@ -108,7 +113,12 @@ pub trait ParRunnerUseRes: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), u.max_threads());
+                let (max_nt, state) = self.nt_state(
+                    params,
+                    I::is_source_serialized(),
+                    iter.size_hint(),
+                    u.max_threads(),
+                );
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results, u) = (&iter, &state, &results_bag, &u);
@@ -173,7 +183,12 @@ pub trait ParRunnerUseRes: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), u.max_threads());
+                let (max_nt, state) = self.nt_state(
+                    params,
+                    I::is_source_serialized(),
+                    iter.size_hint(),
+                    u.max_threads(),
+                );
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 {
@@ -233,7 +248,12 @@ pub trait ParRunnerUseRes: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), u.max_threads());
+                let (max_nt, state) = self.nt_state(
+                    params,
+                    I::is_source_serialized(),
+                    iter.size_hint(),
+                    u.max_threads(),
+                );
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results, u) = (&iter, &state, &results_bag, &u);
@@ -290,7 +310,12 @@ pub trait ParRunnerUseRes: ParRunner {
             }
             false => {
                 let mut spawned = 0;
-                let (max_nt, state) = self.nt_state(params, iter.size_hint(), u.max_threads());
+                let (max_nt, state) = self.nt_state(
+                    params,
+                    I::is_source_serialized(),
+                    iter.size_hint(),
+                    u.max_threads(),
+                );
                 let results_bag = ConcurrentBag::with_fixed_capacity(max_nt);
 
                 let (iter, st, results, u) = (&iter, &state, &results_bag, &u);

--- a/src/runner/par_runner.rs
+++ b/src/runner/par_runner.rs
@@ -38,6 +38,8 @@ pub trait ParRunner: Sized + Sync {
         size_hint: (usize, Option<usize>),
     ) -> Self::State;
 
+    fn configure_for_serialized_input(state: &mut Self::State, size_hint: (usize, Option<usize>));
+
     fn begin_thread(state: &Self::State, th_idx: usize);
 
     /// Returns the next chunk size to be pulled from the input with remaining length
@@ -64,6 +66,7 @@ pub trait ParRunner: Sized + Sync {
     fn nt_state(
         &mut self,
         params: Params,
+        is_source_serialized: bool,
         size_hint: (usize, Option<usize>),
         computation_max_nt: Option<usize>,
     ) -> (usize, Self::State) {
@@ -77,7 +80,10 @@ pub trait ParRunner: Sized + Sync {
             _ => max_nt,
         };
 
-        let state = self.new_state(params, max_nt, size_hint);
+        let mut state = self.new_state(params, max_nt, size_hint);
+        if is_source_serialized {
+            Self::configure_for_serialized_input(&mut state, size_hint);
+        }
         (max_nt, state)
     }
 
@@ -141,5 +147,9 @@ impl<P: ParRunner> ParRunner for &mut P {
 
     fn complete_computation(state: Self::State) {
         <P as ParRunner>::complete_computation(state);
+    }
+
+    fn configure_for_serialized_input(state: &mut Self::State, size_hint: (usize, Option<usize>)) {
+        <P as ParRunner>::configure_for_serialized_input(state, size_hint);
     }
 }

--- a/src/runner/runner_variants/adaptive_chunk/adaptive_chunk_runner.rs
+++ b/src/runner/runner_variants/adaptive_chunk/adaptive_chunk_runner.rs
@@ -4,6 +4,7 @@ use super::state::State;
 use crate::parameters::{ChunkSize, Params};
 use crate::pool::ParThreadPool;
 use crate::runner::par_runner::ParRunner;
+use crate::runner::runner_variants::fixed_chunk::heuristic;
 
 #[derive(Clone)]
 pub struct AdaptiveChunkRunner<P: ParThreadPool> {
@@ -66,6 +67,12 @@ impl<P: ParThreadPool> ParRunner for AdaptiveChunkRunner<P> {
             fixed_chunk_size,
             initial_len,
         )
+    }
+
+    fn configure_for_serialized_input(state: &mut Self::State, size_hint: (usize, Option<usize>)) {
+        let chunk_size =
+            heuristic::compute_chunk_size(ChunkSize::Auto, size_hint, state.max_num_threads);
+        state.set_fixed_chunk_size(chunk_size);
     }
 
     #[inline(always)]

--- a/src/runner/runner_variants/adaptive_chunk/state.rs
+++ b/src/runner/runner_variants/adaptive_chunk/state.rs
@@ -62,6 +62,11 @@ impl State {
         self.mode.complete_exploration();
     }
 
+    pub(super) fn set_fixed_chunk_size(&self, chunk_size: usize) {
+        self.chosen_chunk_size.store(chunk_size, Ordering::Relaxed);
+        self.mode.complete_exploration();
+    }
+
     pub(super) fn record_chunk(&self, chunk_state: ChunkState) {
         let elapsed_ns = chunk_state.elapsed_ns();
         let items = chunk_state.requested_chunk_size.max(1);

--- a/src/runner/runner_variants/fixed_chunk/fixed_chunk_runner.rs
+++ b/src/runner/runner_variants/fixed_chunk/fixed_chunk_runner.rs
@@ -48,6 +48,12 @@ impl<P: ParThreadPool> ParRunner for FixedChunkRunner<P> {
         }
     }
 
+    fn configure_for_serialized_input(
+        _state: &mut Self::State,
+        _size_hint: (usize, Option<usize>),
+    ) {
+    }
+
     #[inline(always)]
     fn begin_thread(_: &Self::State, _: usize) {}
 

--- a/src/runner/runner_variants/with_diagnostics.rs
+++ b/src/runner/runner_variants/with_diagnostics.rs
@@ -41,6 +41,10 @@ impl<R: ParRunner> ParRunner for WithDiagnostics<R> {
         StateWithDiagnostics::new(max_num_threads, inner)
     }
 
+    fn configure_for_serialized_input(state: &mut Self::State, size_hint: (usize, Option<usize>)) {
+        R::configure_for_serialized_input(&mut state.inner, size_hint);
+    }
+
     fn begin_thread(state: &Self::State, th_idx: usize) {
         state.thread_lifetimes.begin(th_idx);
         R::begin_thread(&state.inner, th_idx);


### PR DESCRIPTION
Performance optimization for iter-of-iter (arbitrary) computations.
